### PR TITLE
Fix for examining cosmetics in shops.

### DIFF
--- a/src/000-SCRIPT_OBJ/Items.js
+++ b/src/000-SCRIPT_OBJ/Items.js
@@ -172,7 +172,7 @@ window.App.Item = new function() {
             this.Examine = function (Player) {
                 var Output = this.Data["LongDesc"];
                 var Usages = Player.GetHistory("ITEMS", this.Name());
-                var Effects = Object.keys(this.Data["UseEffect"]);
+                var Effects = Object.keys(this.Data["UseEffect"] || {});
 
                 if (Usages == 0) return Output;
 


### PR DESCRIPTION
Error: <<print>>: bad evaluation: can't convert undefined to object

Didn't test examining makeup and the Isla shop, should fix examining for any item without UseEffect.