### PR TITLE
Workaround inventory update bug after loading a save

### DIFF
--- a/src/000-SCRIPT_OBJ/EventHandlers.js
+++ b/src/000-SCRIPT_OBJ/EventHandlers.js
@@ -153,5 +153,7 @@ App.EventHandlers = new function() {
         }
 
         save.id = SugarCube.session.id; // the game title includes version, hence this overwrite
+
+        SugarCube.setup.player.SaveLoaded()
     };
 };

--- a/src/000-SCRIPT_OBJ/Player.js
+++ b/src/000-SCRIPT_OBJ/Player.js
@@ -1993,4 +1993,9 @@ App.Entity.Player = class Player {
     get CurrentSlots() { return this._state.CurrentSlots; } // Starting allocation of whoring
 
     get MaxSlots() { return 9; } // YOU SHALL NOT PASS
+
+    SaveLoaded() {
+        delete this._inventory;
+        delete this._clothing;
+    }
 };


### PR DESCRIPTION
When a save is loaded, the `PlayerState` is replaced but `InventoryManager` and `ClothingManager` keep track the old objects. This patch resets references to those objects and they are re-created with the next access to the inventory or the wardrobe.

Perhaps a better way would be to use `SuragCube.State.variables.PlayerState` object directly (as the `Player` class does), but a refresh would be needed anyway in order to update the `Item` objects.