### PR TITLE
Fix rebasing issue int Item.Factory()

### DIFF
--- a/src/000-SCRIPT_OBJ/Items.js
+++ b/src/000-SCRIPT_OBJ/Items.js
@@ -280,7 +280,7 @@ App.Item = class Item {
         if (Type == "DRUGS" || Type == "FOOD" || Type == "COSMETICS" || Type == "LOOT_BOX" || Type == 'MISC_CONSUMABLE') {
              o = new App.Items.Consumable(Type, d, Inventory);
         }
-        if (Count != 0 ) o.SetCharges(Count);
+        if (Count > 0 ) o.SetCharges(Count);
 
         return o;
     }


### PR DESCRIPTION
For items that do not support charges we omit the Count parameter. Thus
test it for '> 0' instead of '!= 0' (which yields true for undefined)
before calling the SetCharges function.