### PR TITLE
Properly identify static function to get phase icon

### DIFF
--- a/src/000-SCRIPT_OBJ/JobEngine.js
+++ b/src/000-SCRIPT_OBJ/JobEngine.js
@@ -562,7 +562,7 @@ App.Job = function(Data) {
         if (this.OnCoolDown(Player) == false && this._CheckTime(Player) == false) {
           Output = "@@color:yellow;Only Available@@ ";
             for (var i = 0; i < this.Phases().length; i++)
-                Output += Player.GetPhaseIcon(this.Phases()[i]) + " ";
+                Output += App.Entity.Player.GetPhaseIcon(this.Phases()[i]) + " ";
         }
 
         if (this._MissingRequirements.length > 0)


### PR DESCRIPTION
Fixes commit f3b59749b15f33c3d3e7dd9ea60854376fea71ef.

Error message: Error: <<jobButton>>: error within widget contents (Error: <<print>>: bad evaluation: Player.GetPhaseIcon is not a function)