### PR TITLE
Refactor clothing locking

### DIFF
--- a/src/000-SCRIPT_OBJ/Items.js
+++ b/src/000-SCRIPT_OBJ/Items.js
@@ -411,6 +411,13 @@ App.Item = class Item {
     }
 
     /**
+     * @returns {InventoryManager}
+     */
+    get Inventory() {
+        return this._inventory;
+    }
+
+    /**
      * @returns {object}
      */
     get Data() {
@@ -515,8 +522,7 @@ App.Items.Clothing = class Clothing extends App.Item {
         if (typeof (result) !== "string" || result === "") return this.Name();
         result = result.replace("{COLOR}", String(this.Data.Color));
 
-        var locked = this.Data.Locked;
-        if (typeof (locked) === "boolean" && locked) result += " @@color:red;(Locked)@@";
+        if (this.IsLocked()) result += " @@color:red;(Locked)@@";
 
         return result;
     }
@@ -692,18 +698,13 @@ App.Items.Clothing = class Clothing extends App.Item {
         return this.Data["HairBonus"] ? this.Data["HairBonus"] : 0;
     }
 
-    /** @returns {boolean} */
-    IsLocked() {
-        var locked = this.Data.Locked;
-        return typeof (locked) === "boolean" ? locked : false;
-    }
-
     /**
      * Locked items cannot be removed unless unlocked.
-     * @param {boolean} locked
      */
-    SetIsLocked(locked) {
-        this.Data.Locked = locked;
+    IsLocked() {
+        if (this.Inventory.IsWorn(this.Id(), this.Slot())) return this.Inventory.IsLocked(this.Slot());
+        var locked = this.Data.Locked;
+        return typeof (locked) === "boolean" ? locked : false;
     }
 
     /**

--- a/src/200-WIDGETS/InventoryWidgets.twee
+++ b/src/200-WIDGETS/InventoryWidgets.twee
@@ -331,12 +331,11 @@
 <<else>>
 @@.wardrobeButton;<<button "Swap">>
 <<set _Current = setup.player.GetEquipmentInSlot("Neck");>>
+<<set _CurentIsLocked = _Current.IsLocked();>>
 <<set _New = setup.player.GetItemById($args[0]);>>
 <<run setup.player.AdjustMoney(-300);>>
-<<run _Current.o.Locked = false;>>
-<<run setup.player.Wear( setup.player.GetItemById($args[0]));>>
-<<run _New.o.Locked = true>>
-<<goto "CollarSwap">>
+<<run setup.player.Wear(setup.player.GetItemById($args[0]), _CurentIsLocked);>>
+<<goto "CollarSwap">>s
 <</button>>@@
 <</if>>
 <</nobr>><</widget>>


### PR DESCRIPTION
This corrects bugs with locked items after the inventory refactor. Since
the "Locked" property is now belongs to the player state object, the
`Player.Wear()` function learned additional parameter `lock` to specify
whether the new item has to be locked in the slot after putting it on.
Items can be unlocked using the same parameter.