### PR TITLE
Work around crash when creating items without inventory

### DIFF
--- a/src/000-SCRIPT_OBJ/Items.js
+++ b/src/000-SCRIPT_OBJ/Items.js
@@ -284,7 +284,10 @@ App.Item = class Item {
              o = new App.Items.Consumable(Type, Tag, d, Inventory);
         }
 
-        if (Count == undefined) Count = Item.GetCharges(undefined, undefined, d);
+        // HACK: when an item is created in an "disconnected" state, without an inventory manager,
+        // this probably mean we want to get a description from the item. Thus we discard charges
+        // from the data record in that case.
+        if (Inventory !== undefined && Count == undefined) Count = Item.GetCharges(undefined, undefined, d);
         if (Count > 1) o.AddCharges(Count - 1);
 
         return o;


### PR DESCRIPTION
When item is created from a data record with charges greater than 1,
Factory attempts to call AddCharges() and that fails if inventory
manager was not supplied. This happens when we print out item
description for a quest. Therefore as a (temporal) workaround we discard
charges information when inventory object is not available.