### PR TITLE
Show detailed information in shops and inventory

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -251,18 +251,19 @@ App.PR = new function() {
         this.pEffectMeter = function(effect, item)
         {
             var output = "";
+            var effectStr = effect.replace(/ /g, '&nbsp;');
 
             // Build color and arrow
             if (effect.indexOf('-') != -1 ) {
-                output = "@@color:red;"+effect+"@@";
+                output = "@@color:red;"+effectStr+"@@";
                 output = output.replace(/-/g, '&dArr;');
             } else
             if (effect.indexOf('+') != -1) {
-                output = "@@color:lime;"+effect+"@@";
+                output = "@@color:lime;"+effectStr+"@@";
                 output = output.replace(/\+/g, '&uArr;');
             } else
             if (effect.indexOf('?') != -1) {
-                output = "@@color:lime;&uArr;"+effect+"@@";
+                output = "@@color:lime;&uArr;"+effectStr+"@@";
                 if (typeof item.o['Style'] !== 'undefined') {
                     switch(item.o['Style']) {
                         case 'COMMON': output = output.replace(/RANK/g, "&uArr;" ); break;
@@ -272,7 +273,7 @@ App.PR = new function() {
                     }
                 }
             } else {
-                output = "@@color:grey;"+effect+"@@";
+                output = "@@color:grey;"+effectStr+"@@";
                 output =  output.replace(/RANK/g, "&uArr;");
             }
 
@@ -828,6 +829,23 @@ App.PR = new function() {
         } catch (err) {
             //no-op
         }
+    };
+
+    /**
+     * Prints item description for the inventory list
+     * @param {(App.Items.Clothing|App.Items.Consumable|App.Items.QuestItem)} Item
+     * @param {App.Entity.Player} Player
+     * @return {html}
+     */
+    this.PrintItem = function(Item, Player)
+    {
+        var res = "<span class='inventoryItem'>" + Item.Description();
+        if (SugarCube.settings.inlineItemDetails) {
+            res += "</span><br><span class='inventoryItemDetails'>" + Item.Examine(Player, true) + '</span>';
+        } else {
+            res += '<span class="tooltip">' + Item.Examine(Player, false) + '</span></span>';
+        }
+        return res;
     };
 };
 

--- a/src/000-SCRIPT_OBJ/Items.js
+++ b/src/000-SCRIPT_OBJ/Items.js
@@ -535,10 +535,11 @@ App.Items.Clothing = /** @class Clothing @extends {App.Item} */ class Clothing e
     /**
      * Examine an item, relate detailed description and any knowledge.
      * @param {App.Entity.Player} Player
+     * @param {boolean} [OmitDescription]
      * @returns {string}
      */
-    Examine(Player) {
-        var Output = this.Data["LongDesc"];
+    Examine(Player, OmitDescription) {
+        var Output = OmitDescription ? "" : this.Data["LongDesc"];
         var Usages = Player.GetHistory("CLOTHING_EFFECTS_KNOWN", this.Tag());
 
         Output += "\n";
@@ -768,19 +769,20 @@ App.Items.Consumable = /** @class Consumable @extends {App.Item} */ class Consum
     /**
      * Shows long description of item and any knowledge known about it.
      * @param {App.Entity.Player} Player
+     * @param {boolean} [OmitDescription]
      * @returns {string}
      */
-    Examine(Player) {
-        var Output = this.Data["LongDesc"];
+    Examine(Player, OmitDescription) {
+        var Output = OmitDescription ? "" : this.Data["LongDesc"];
         var Usages = Player.GetHistory("ITEMS", this.Tag());
 
         if (Usages == 0) return Output;
 
-        Output += "\n\n";
+        if (!OmitDescription) Output += "\n\n";
         var max = Math.min(Usages, this.GetKnowledge().length);
 
         for(var i = 0; i < max; i++)
-            Output += App.PR.pEffectMeter(this.GetKnowledge()[i], this) + "&nbsp;&nbsp;";
+            Output += App.PR.pEffectMeter(this.GetKnowledge()[i], this) + "  ";
 
         return Output;
     }
@@ -921,10 +923,11 @@ App.Items.QuestItem = /** @class QuestItem @extends {App.Item} */ class QuestIte
     /**
      * Long description of item. No knowledge on quest items.
      * @param {App.Entity.Player} Player
+     * @param {boolean} [OmitDescription]
      * @returns {string}
      */
-    Examine(Player) {
-        return this.Data["LongDesc"];
+    Examine(Player, OmitDescription) {
+        return OmitDescription ? "" : this.Data["LongDesc"];
     }
 
     /**
@@ -979,12 +982,13 @@ App.Items.Reel = /** @class Reel @extends {App.Item} */ class Reel extends App.I
 
     /**
      * @param {App.Entity.Player} Player
+     * @param {boolean} [OmitDescription]
      * @returns {string}
      */
-    Examine(Player) {
+    Examine(Player, OmitDescription) {
         var attrs = [ 'ASS', 'BJ', 'HAND', 'TITS', 'FEM', 'PERV', 'BEAUTY'];
         var text = ['Ass Fucking', 'Blowjobs', 'Handjobs', 'Tit Fucking', 'Femininity', 'Perversion', 'Beauty'];
-        var output = "A slot reel used for whoring. It has the following attributes:\n";
+        var output = OmitDescription ? "" : "A slot reel used for whoring. It has the following attributes:\n";
         for (var x = 0; x < attrs.length; x++) {
             var percent = this.CalcPercent(attrs[x]);
             if (percent <= 0) continue;

--- a/src/000-SCRIPT_OBJ/StoreEngine.js
+++ b/src/000-SCRIPT_OBJ/StoreEngine.js
@@ -213,6 +213,27 @@ var Store = function(Player, NPC, StoreData) {
         }
     };
 
+    /**
+     * Returns days until the next restocking
+     * @returns {number}
+     */
+    this.DaysUntilRestocking = function()
+    {
+        // Don't stock stuff in markets
+        if (this._Data["RESTOCK"] == 0) return 0;
+        return this._Data["RESTOCK"] - (this._Player.Day
+             - this._Player.StoreInventory[this._Data["ID"]]["LAST_STOCKED"]);
+    };
+
+    /**
+     * Owner's mood
+     * @returns {number}
+     */
+    this.OwnerMood = function()
+    {
+        return this._NPC.Mood();
+    };
+
     /* FIXME: Let's make this trigger for the SHIP whenever you land at a port. But not otherwise. */
     this.StockInventory = function()
     {
@@ -244,9 +265,15 @@ var Store = function(Player, NPC, StoreData) {
     this.PrintItem = function(Item)
     {
         var oItem = window.App.Item.Factory( Item["TYPE"], Item["TAG"]);
-        var res = oItem.Description();
+        var res = "<span class='inventoryItem'>" + oItem.Description();
         if (this._Player.Inventory.IsFavorite(oItem.Id())) {
             res += "&nbsp;" + App.PR.GetItemFavoriteIcon(true);
+        }
+
+        if (SugarCube.settings.inlineItemDetails) {
+            res += "</span><br><span class='inventoryItemDetails'>" + oItem.Examine(this._Player, true) + '</span>';
+        } else {
+            res += '<span class="tooltip">' + oItem.Examine(this._Player, false) + '</span></span>';
         }
         return res;
     };

--- a/src/002-ASSETS/CSS/custom.css
+++ b/src/002-ASSETS/CSS/custom.css
@@ -156,3 +156,56 @@ input[type="text"] {
 	top: 0;
 	left: 0;
 }
+
+.shopName {
+	font-size:larger;
+	text-align:center;
+	color: cyan;
+	position: relative;
+}
+
+.shopName .tooltip {
+	font-size: small;
+	visibility: hidden;
+	text-align: center;
+	border-radius: 4px;
+	border: 1px solid white;
+	padding: 5px 0;
+	background-color: black;
+	width: 30em;
+	position: absolute;
+	z-index: 1;
+	bottom: 150%;
+	left: 20%;
+}
+
+.shopName:hover .tooltip {
+	visibility: visible;
+}
+
+.inventoryItem {
+	position: relative;
+}
+
+.inventoryItem .tooltip {
+	visibility: hidden;
+	text-align: left;
+	border-radius: 4px;
+	border: 1px solid rgb(126, 200, 243);
+	padding: 5px 5px;
+	background-color: black;
+	width: 30em;
+	position: absolute;
+	z-index: 1;
+	bottom: 150%;
+	left: 20%;
+}
+
+.inventoryItem:hover .tooltip {
+	visibility: visible;
+}
+
+.inventoryItemDetails {
+	font-size:small;
+	padding-left:2em;
+}

--- a/src/200-WIDGETS/InventoryWidgets.twee
+++ b/src/200-WIDGETS/InventoryWidgets.twee
@@ -196,7 +196,7 @@
 <td><<= "<<FavoriteItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 <td><<= _Items[_i].Charges() >></td>
 <td style="text-align:left"><<= "<<ThrowItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
-<td><<= _Items[_i].Description() >></td>
+<td><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>
 <td style="text-align:right">&nbsp;</td>
 <td style="text-align:right"><<= "<<ExamineItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 </tr>
@@ -222,7 +222,7 @@
 <<for _i = 0; _i lt _Items.length; _i++>>
 <tr>
     <td style="width:80px;"><<if _i eq 0>>''@@color:gold;<<= _Slots[_x] >>@@''<</if>></td>
-    <td style="width:680px;"><<if  setup.player.Equipment[_Slots[_x]] eq _Items[_i]>>(@@color:lime;worn@@) <</if>><<= _Items[_i].Description() >></td>
+    <td style="width:680px;"><<if  setup.player.Equipment[_Slots[_x]] eq _Items[_i]>>(@@color:lime;worn@@) <</if>><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>
     <td style="text-align:right"><<= "<<ExamineItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 </tr>
 <</for>>
@@ -243,7 +243,7 @@
 <td><<= "<<FavoriteItemButton \""+ _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 <td><<= _Items[_i].Charges() >></td>
 <td style="text-align:left"><<= "<<ThrowItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
-<td><<= _Items[_i].Description() >></td>
+<td><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>
 <td style="text-align:right"><<= "<<UseItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 <td style="text-align:right"><<= "<<ExamineItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 </tr>
@@ -263,7 +263,7 @@
 <td><<= "<<FavoriteItemButton \""+ _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 <td><<= _Items[_i].Charges() >></td>
 <td style="text-align:left"><<if _Items[_i].Type() == "LOOT_BOX">><<= "<<ThrowItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >><</if>></td>
-<td><<= _Items[_i].Description() >></td>
+<td><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>
 <td style="text-align:right"><<if _Items[_i].Type() == "LOOT_BOX">><<= "<<UseItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >><</if>></td>
 <td style="text-align:right"><<= "<<ExamineItemButton \"" + _Items[_i].Id() + "\" \"" + $args[0] + "\" >>" >></td>
 </tr>

--- a/src/200-WIDGETS/storeInventory.twee
+++ b/src/200-WIDGETS/storeInventory.twee
@@ -5,13 +5,32 @@
 <<set _ST = _SE.OpenStore(setup.player, _NPC);>>\
 <<set _CI = _ST.GetCommonInventory();>>\
 <<set _RI = _ST.GetRareInventory(); >>\
+<<if _ST.OwnerMood() >= 80>>\
+	<<set _DUR = _ST.DaysUntilRestocking() >>
+	<<if _DUR > 0>>
+		<<set _restockingText to "Restocking in " + _DUR + " days">>
+	<<else>>
+		<<set _restockingText to "Fresh supplies arrived this morning!">>
+	<</if>>
+	<<if SugarCube.settings.inlineItemDetails>>\
+		<<set _restockHint to "">>
+		<<set _restockCell to "<td colspan=\"2\">" + _restockingText + "</td>">>
+	<<else>>
+		<<set _restockHint to "<span class=\"tooltip\">" + _restockingText + "</span>">>
+		<<set _restockCell to "">>
+	<</if>>
+<<else>>
+	<<set _restockHint to "">>
+	<<set _restockCell to "">>
+<</if>>
 <<nobr>>
 <table class=".MyTable">
 <tbody>
-<tr><td colspan="5" style="font-size:larger;text-align:center;">@@color:cyan;<<print _ST.GetName();>>@@</td>
+<tr><td colspan="3" class="shopName"><span><<print _ST.GetName();>><<= _restockHint>></span></td>
+<<= _restockCell>>
 </tr>
 <tr style="border-bottom:solid 1px white;">
-<td style="width: 320px;">@@color:yellow;General Items@@</td>
+<td style="width: 420px;">@@color:yellow;General Items@@</td>
 <td style="width: 80px;font-size:smaller;text-align:center;">Quantity</td>
 <td style="width: 60px;font-size:smaller;text-align:right;">Price</td>
 <td style="width: 80px;"> </td>
@@ -24,7 +43,7 @@
 <<else>>
 <<for _i = 0; _i lt _CI.length; _i++>>
 <tr>
-<td>  <<print _ST.PrintItem(_CI[_i]);>></td>
+<td> <<print _ST.PrintItem(_CI[_i]);>></td>
 <td style="text-align:center;"><<print _CI[_i]["QTY"]>></td>
 <td style="text-align:right;"><<print _ST.GetPrice(_CI[_i]);>></td>
 <td style="text-align:center;"><<storeButton _CI[_i]>></td>

--- a/src/main.twee
+++ b/src/main.twee
@@ -17,37 +17,45 @@ setup.player = new App.Entity.Player();
 
 // Override navigation on death.
 Config.navigation.override = function (passageName) {
-        if (App.EventHandlers.HasPlayerState() == false) return; //ignore these checks if there is no player state.
-        if (setup.player.GetStat("STAT", "Health") <= 0) {
-            State.temporary.followup = passageName;
-            return "DeathEnd";
-        }
+    if (App.EventHandlers.HasPlayerState() == false) return; //ignore these checks if there is no player state.
+    if (setup.player.GetStat("STAT", "Health") <= 0) {
+        State.temporary.followup = passageName;
+        return "DeathEnd";
+    }
 
-        if (setup.player.GetStat("STAT", "WillPower") < 20) {
-            State.temporary.followup = passageName;
-            return "WillPowerEnd";
-        }
-    };
+    if (setup.player.GetStat("STAT", "WillPower") < 20) {
+        State.temporary.followup = passageName;
+        return "WillPowerEnd";
+    }
+};
 
-    // Setting for showing numbers along with the meters
-    Setting.addToggle("displayMeterNumber", {
-        label    : "Display numbers in (pseudo-)graphical meters",
-        desc     : "Controls printing number values for each meter bar in addition to the graphical representation",
-        default  : false,
-        onInit   : handleMetersNumberValueSettingChanged,
-        onChange : handleMetersNumberValueSettingChanged
-      });
+Setting.addHeader("Display settings");
 
-    App.unitSystem = new App.UnitSystem();
-    // Setting up a basic list control for the settings property 'units'
-    Setting.addList("units", {
-        label   : "Unit system",
-        desc    : "Choose the unit system.",
-        list    : ["Imperial", "Metric"],
-        default : "Imperial",
-        onInit  : unitSettingChangedHandler,
-        onChange: unitSettingChangedHandler
+// Setting for showing numbers along with the meters
+Setting.addToggle("displayMeterNumber", {
+    label    : "Show numbers in (pseudo-)graphical meters",
+    desc     : "Controls printing number values for each meter bar in addition to the graphical representation",
+    default  : false,
+    onInit   : handleMetersNumberValueSettingChanged,
+    onChange : handleMetersNumberValueSettingChanged
     });
+
+App.unitSystem = new App.UnitSystem();
+// Setting up a basic list control for the settings property 'units'
+Setting.addList("units", {
+    label   : "Unit system",
+    desc    : "Choose the unit system.",
+    list    : ["Imperial", "Metric"],
+    default : "Imperial",
+    onInit  : unitSettingChangedHandler,
+    onChange: unitSettingChangedHandler
+});
+
+Setting.addToggle("inlineItemDetails", {
+    label    : "Inline detailed information in inventory and shops",
+    desc     : "Toggles displaying additional information in the inventory and shop interfaces.\nDetailed item information will be inlined if setting is enabled or shown in tooltips otherwise",
+    default  : false
+});
 
 App.EventHandlers.Init();
 
@@ -333,20 +341,20 @@ He sighs. "That's what makes a man, is it? I think not. What parts we have matte
 <<click "Of course not.">>
     <<run setup.player.AdjustStat("WillPower", -5);>>
     <<replace "#shame">>"Of course not," you say.
-    
+
     "Of course not," he agrees with a smile and nod. "Girls are beautiful creatures indeed and, the truth is, men only serve to nuture you. If anyone should be ashamed, it is me, not you. I've been remiss in my chivalrous duties!"<</replace>>
     <<replace "#nextPage">>[[You watch him retrieve a bucket from near the cell door.|IntroSlow3]]<</replace>>
 <</click>>
 <<click "No, but I'm not a lovely lass.">>
     <<run setup.player.AdjustStat("WillPower", -5);>>
     <<replace "#shame">>"No," you say, "but I'm not a lovely lass."
-    
+
     "Perhaps you don't see it... yet," he says, "but I see it very clearly. And with a little care, I'm quite certain you'll see it, too. I would be honored to help you see what a lovely lass you are indeed."<</replace>>
     <<replace "#nextPage">>[[You watch him retrieve a bucket from near the cell door.|IntroSlow3]]<</replace>>
 <</click>>
 <<click "Girls are fragile and silly!">>
     <<replace "#shame">>"Girls are fragile and silly!" you tell him.
-    
+
     "Fragile and silly?" He sighs. "I simply must beg to differ. Women are the entire reason men exist at all. You are our poetry. You are the sun and the moon. Fine lasses like yourself, @@color:deepPink;<<= setup.player.SlaveName>>@@, are our very hearts. Everything we do that is neither fragile nor silly we do in your honor. And I would very much like to show you how much I respect that."<</replace>>
     <<replace "#nextPage">>[[You watch him retrieve a bucket from near the cell door.|IntroSlow3]]<</replace>>
 <</click>>


### PR DESCRIPTION
Adds a setting to toggle displaying detailed item information inline or as tooltips:
![setting](https://user-images.githubusercontent.com/43062025/46740418-12af1600-cca3-11e8-994c-fd9084522a2d.png)

And that looks as follows.
Tooltips (default):
![tooltip](https://user-images.githubusercontent.com/43062025/46740498-468a3b80-cca3-11e8-8441-203778480460.png)

Inlined:
![details](https://user-images.githubusercontent.com/43062025/46740519-5570ee00-cca3-11e8-8f40-8b699e19bcb9.png)
