### PR TITLE
Replace megatools with megacmd in the publishing script.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,11 @@ environment:
 
 install:
 - sh: >-
-    sudo apt-get install -yq megatools
+    wget https://mega.nz/linux/MEGAsync/xUbuntu_18.04/amd64/megacmd-xUbuntu_18.04_amd64.deb
+
+    sudo dpkg -i megacmd-xUbuntu_18.04_amd64.deb && rm megacmd-xUbuntu_18.04_amd64.deb
+
+    sudo apt-get install -fyq
 
     wget http://www.motoslave.net/tweego/download.php/tweego-${TWEEGO_VERSION}-linux-x64.zip
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,7 +4,8 @@
 # $2: optional tag name
 
 if [ $# -eq 0 ]; then
-	echo "Usage: $0 GIT_BRANCH_NAME [GIT_TAG]"
+	echo "Usage: $0 GIT_BRANCH_NAME [GIT_TAG]";
+	exit 1;
 fi
 
 BRANCH_NAME="${1}"
@@ -28,11 +29,10 @@ pack_output() {
 # $1: file to upload
 # $2: dir to upload into
 upload() {
-	megamkdir -u $MEGA_LOGIN -p $MEGA_PWD /Root/Queen/"${2}" || true
-	megarm -u $MEGA_LOGIN -p $MEGA_PWD "/Root/Queen/${2}/${1}" || true
-	megaput -u $MEGA_LOGIN -p $MEGA_PWD --path="/Root/Queen/${2}" "${1}"
+	mega-login "$MEGA_LOGIN" "$MEGA_PWD"
+	mega-put -c "${1}" Queen/"${2}"
+	mega-logout
 }
-
 
 pack_output "$(archive_name)"
 upload "$(archive_name)" "$(target_dir)"


### PR DESCRIPTION
Megatools can't add files to a shared folder (the uploaded file is not
downloadable (https://github.com/megous/megatools/issues/54). mega-put
from the megacmd package does not have this problem.