### PR TITLE
Add support for leveled nouns

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -15,30 +15,204 @@ App.PR = new function() {
 	};
 
     /**
+     * Returns config object which describe naming of the given type
+     * @param {string} Type Config type ("BODY")
+     * @returns {any}
+     */
+    this.GetNamingConfig = function(Type) {
+        if (Type == "BODY") return App.Data.Naming.BodyConfig;
+    };
+
+    /**
+     * Fetch index names required to find leveld value for a leveling property
+     * @param {string} Stat Stat type (SKILL, BODY, STAT)
+     * @param {string} Property Property name ("Bust", "Lips", etc.)
+     * @param {string} Aspect "NOUN", "ADJECTIVE"
+     * @return {string[]}
+     */
+    this.GetNamingIndicies = function(Stat, Property, Aspect) {
+        var st = this.GetNamingConfig(Stat);
+        if (st == undefined || !st.hasOwnProperty(Property) || !st[Property].hasOwnProperty(Aspect)) return undefined;
+        return st[Property][Aspect].hasOwnProperty("INDEX") ? st[Property][Aspect]["INDEX"] : [Property];
+    };
+
+    /**
+     * @summary Fetch a leveled value from the given rating for given values.
+     *
+     * This function descends into the passed ratings object using supplied index
+     * value array. The rating object is indexed as using the first element of the
+     * index array. The result of this operation is passed to this function again with
+     * sliced index array. This continues until index array is exhausted or indexing
+     * returns a simple string or array of strings (a random element of wchih is returned then).
+     *
+     * @param {(object|string)} Ratings object with ratings or the final string
+     * @param {(number[]|number)} Value array of rating index values or a single value
+     * @returns {string}
+     */
+    this.GetMultiIndexLevelingProperty = function(Ratings, Value) {
+        if (typeof(Ratings) == "string") return Ratings; // value does not change
+
+        var v;
+        var nextValues = undefined;
+        if (Array.isArray(Value)) {
+            v = Value[0];
+            if (Value.length > 1) nextValues = Value.slice(1);
+        } else {
+            v = Value;
+        }
+        var lastSmallerRating;
+        for (var prop in Ratings) {
+            if (!Ratings.hasOwnProperty(prop)) continue;
+            if (prop > v) break;
+            lastSmallerRating = prop;
+        }
+        if (lastSmallerRating == undefined)  return "Untyped rating: " + Value;
+        var res = Ratings[lastSmallerRating];
+        if (nextValues == undefined) {
+            if (Array.isArray(res)) {
+                return res.random(); // SugarCube adds Array.random()
+            } else {
+                return res;
+            }
+        }
+        return this.GetMultiIndexLevelingProperty(res, nextValues);
+	};
+
+    /**
      * Fetch a rating for a statistic/value
      * @param Type
-     * @param Value
+     * @param {number|number[]} Value
      * @param [Colorize]
      * @returns {string}
      */
-	    this.GetRating = function (Type, Value, Colorize) {
-            Colorize    = Colorize || false;
-            var Ratings  = App.Data.Ratings[Type];
+	this.GetRating = function (Type, Value, Colorize) {
+        Colorize    = Colorize || false;
+        var Ratings  = App.Data.Ratings[Type];
 
-            var lastSmallerRating;
-            for (var prop in Ratings) {
-                if (!Ratings.hasOwnProperty(prop)) continue;
-                if (prop > Value) break;
-                lastSmallerRating = prop;
-            }
+        var lastSmallerRating;
+        for (var prop in Ratings) {
+            if (!Ratings.hasOwnProperty(prop)) continue;
+            if (prop > Value) break;
+            lastSmallerRating = prop;
+        }
 
-            if (lastSmallerRating == undefined)  return "Untyped rating: " + Type + "," + Value;
-            if (Colorize == true) {
-                return this.ColorizeString(Value, Ratings[lastSmallerRating]);
-            } else {
-                return Ratings[lastSmallerRating];
+        if (lastSmallerRating == undefined)  return "Untyped rating: " + Type + "," + Value;
+        if (Colorize == true) {
+            return this.ColorizeString(Value, Ratings[lastSmallerRating]);
+        } else {
+            return Ratings[lastSmallerRating];
+        }
+    };
+
+	/**
+     * Helper function. Checks relevant statistic config and returns the leveling record if one exists.
+     * @param {string} Type
+     * @param {string} Stat
+     * @param {number} Value
+     * @returns {*}
+     */
+	this.GetLevelingRecord = function(Type, Stat, Value) {
+        var Ratings = this.GetStatConfig(Type)[Stat].LEVELING;
+        var lastSmallerProp;
+        for (var prop in Ratings) {
+            if (!Ratings.hasOwnProperty(prop)) continue;
+            if (prop > Value) break;
+            lastSmallerProp = prop;
+        }
+        if (lastSmallerProp !== undefined) return Ratings[lastSmallerProp];
+        return undefined;
+    };
+
+    /**
+     * Helper function. Checks relevant statistic config and returns a colorized Property value for use if one exists.
+     * @param {string} Type
+     * @param {string} Stat
+     * @param {string} Property
+     * @param {number|number[]} Value
+     * @returns {string}
+     */
+    this.GetLevelingProperty = function(Type, Stat, Property, Value) {
+        var propValue = this.GetLevelingRecord(Type, Stat, Value);
+        if (propValue == undefined) return "";
+
+        var Arr = App.Data.Lists.ColorScale;
+        return "@@color:" + Arr[propValue.COLOR] + ";" + propValue[Property] +"@@";
+    };
+
+    /**
+     * Helper function. Checks relevant statistic config and returns a NOUN (colorized) for use if one exists.
+     * @param {string} Type
+     * @param {string} Stat
+     * @param {number|number[]} Value
+     * @param [Colorize]
+     * @returns {string}
+     */
+    this.GetNoun = function(Type, Stat, Value, Colorize) {
+        var nCfg = this.GetNamingConfig(Type);
+        if (nCfg == undefined || !nCfg.hasOwnProperty(Stat)) return "NO_NOUN_FOR_" + Type + ":" + Stat;
+        var str = this.GetMultiIndexLevelingProperty(nCfg[Stat].NOUN.LEVELING, Value);
+
+        if (Colorize == true) {
+            // use colour from the first index for now
+            // TODO blend colors from all indices
+            var color = this.GetLevelingRecord(Type, Stat, Array.isArray(Value) ? Value[0] : Value).COLOR;
+            return "@@color:" + App.Data.Lists.ColorScale[color] + ";" + str + "@@";
+        }
+        return str;
+    };
+
+	/**
+	 * Returns aray of applicable adjective values for a leveling noun
+	 * @param {string} Type
+	 * @param {string} Stat
+	 * @param {App.Entity.Player} Player
+	 * @returns {string[]}
+	 */
+	this.GetNoneAdjectives = function(Type, Stat, Player) {
+        var tCfg = this.GetNamingConfig(Type);
+        var sCfg = tCfg != undefined ? tCfg[Stat] : undefined;
+        if (sCfg == undefined) return [];
+        var adjCfg = sCfg["ADJECTIVE"];
+        if (adjCfg == undefined) return [];
+
+        var adjectiveRatings = adjCfg.RATING || [Type + '/' + Stat];
+        var adjectiveIndicies = adjCfg.INDEX || adjectiveRatings;
+        var adjectiveApplicableLevels = adjCfg.APPLICABLE_LEVEL || adjectiveRatings.map(x => { return { "MIN" : 0, "MAX" : 100 };});
+
+        var adjs = [];
+        for (var i = 0; i < adjectiveRatings.length; ++i) {
+            var s = adjectiveIndicies[i].split('/');
+            var statVal = Player.GetStatPercent(s[0], s[1]);
+            if (statVal >= adjectiveApplicableLevels[i].MIN && statVal <= adjectiveApplicableLevels[i].MAX) {
+                var r = adjectiveRatings[i].split('/');
+                adjs.push(this.GetAdjective(r[0], r[1], statVal));
             }
-        };
+        }
+
+        return adjs;
+    };
+
+	/**
+	 * Returns leveling noun, optionally with applicable adjectives prepended
+	 * @param {string} Type
+	 * @param {string} Stat
+	 * @param {App.Entity.Player} Player
+	 * @param {boolean} [Adjectives = false] Whether to prepend adjectives
+	 * @param {boolean} [Colorize = false] colorize output
+	 * @return {string}
+	 */
+	this.GetPlayerNoun = function(Type, Stat, Player, Adjectives, Colorize) {
+        var indexNames = this.GetNamingIndicies(Type, Stat, "NOUN");
+        if (indexNames == undefined) return "NO_NOUN_FOR_" + Type + ":" + Stat;
+        var indicies = indexNames.map(s => s.includes('/') ? s.split('/') : [Type, s]);
+        var indexValues = indicies.map(x => Player.GetStat(x[0], x[1]));
+        var str = this.GetNoun(Type, Stat, indexValues, Colorize);
+
+        if (Adjectives == true) {
+            str = this.GetNoneAdjectives(Type, Stat, Player).join(' ') + ' ' + str;
+        }
+        return str;
+    };
 
     /**
      * Helper function. Checks relevant statistic config and returns an ADJECTIVE (colorized) for use if one exists.
@@ -47,20 +221,9 @@ App.PR = new function() {
      * @param {number} Value
      * @returns {string}
      */
-        this.GetAdjective = function(Type, Stat, Value)
-        {
-            var Ratings = this.GetStatConfig(Type)[Stat]["LEVELING"];
-            var Arr = App.Data.Lists.ColorScale;
-            var lastSmallerProp;
-            for (var prop in Ratings) {
-                if (!Ratings.hasOwnProperty(prop)) continue;
-                if (prop > Value) break;
-                lastSmallerProp = prop;
-            }
-            if (lastSmallerProp !== undefined)
-                return "@@color:" + Arr[Ratings[lastSmallerProp]["COLOR"]] + ";" + Ratings[lastSmallerProp]["ADJECTIVE"] +"@@";
-            return "";
-        };
+	this.GetAdjective = function(Type, Stat, Value) {
+		return this.GetLevelingProperty(Type, Stat, "ADJECTIVE", Value);
+	};
 
     /**
      *
@@ -72,17 +235,19 @@ App.PR = new function() {
      */
     this.TokenizeRating = function(Player, Type, Stat, String)
     {
+        var _this = this;
+        function nounReplacer(match, delim) {
+            return _this.GetPlayerNoun(Type, Stat, Player, false, true) + delim;
+        }
+        function adjReplace(match, delim) {
+            return _this.GetAdjective(Type, Stat, Player.GetStat(Type, Stat)) + delim;
+        }
         String = String.replace(/PLAYER_NAME/g, Player.SlaveName);
-        String = String.replace(/pBUST/g, this.pBust(Player, 1));
-        String = String.replace(/pASS/g, this.pAss(Player, 1));
-        String = String.replace(/pCUP/g, this.pCup(Player));
-        String = String.replace(/pHIPS/g, this.pHips(Player, 1));
-        String = String.replace(/pHORMONES/g, this.pHormones(Player, 1));
-        String = String.replace(/ADJECTIVE/g, this.GetAdjective(Type, Stat, Player.GetStat(Type, Stat)));
         String = String.replace(/LENGTH_C/g, this.lengthString(this.StatToCM(Player,Stat), true).toString());
         String = String.replace(/LENGTH/g, this.lengthString(this.StatToCM(Player,Stat), false).toString());
-
-        return String;
+        String = String.replace(/NOUN([^A-Za-z_|$])/g, nounReplacer);
+        String = String.replace(/ADJECTIVE([^A-Za-z_|$])/g, adjReplace);
+        return this.TokenizeString(Player, undefined, String);
     };
 
     /**
@@ -485,27 +650,30 @@ App.PR = new function() {
      * @param {number} Arg
      * @returns {string}
      */
-        this.pAss = function (Player, Arg) {
-            var aPercent = Player.GetStatPercent("BODY", "Ass");
-            var hPercent = Player.GetStatPercent("BODY", "Hips");
+    this.pAss = function (Player, Arg) {
+        var aPercent = Player.GetStatPercent("BODY", "Ass");
+        var fPercent = Player.GetStatPercent("STAT", "Fitness");
 
-            if (typeof Arg !== 'undefined') return this.GetAdjective("BODY", "Ass", aPercent);
+        if (typeof Arg !== 'undefined') {
+            return this.GetAdjective("BODY", "Ass", aPercent) + ' ' + this.GetAdjective("BODY", "AssFirmness", fPercent);
+        }
 
-            var Output = this.TokenizeRating(Player, "BODY", "Ass", this.GetRating("Ass", aPercent));
+        var hPercent = Player.GetStatPercent("BODY", "Hips");
+        var Output = this.TokenizeRating(Player, "BODY", "Ass", this.GetRating("Ass", aPercent));
 
-            if ((aPercent > 30) || (hPercent > 30)) {
-                if ( aPercent  < ( hPercent - 15) ) {
-                    Output += " It is @@color:yellow;disproportionately small@@ for your ";
-                } else if ( aPercent > ( hPercent + 15)) {
-                    Output += " It is @@color:yellow;disproportionately big@@ for your ";
-                } else {
-                    Output += " It is @@color:lime;flattered@@ by your ";
-                }
-                Output += this.GetAdjective("BODY", "Hips", hPercent) + " hips.";
+        if ((aPercent > 30) || (hPercent > 30)) {
+            if ( aPercent  < ( hPercent - 15) ) {
+                Output += " It is @@color:yellow;disproportionately small@@ for your ";
+            } else if ( aPercent > ( hPercent + 15)) {
+                Output += " It is @@color:yellow;disproportionately big@@ for your ";
+            } else {
+                Output += " It is @@color:lime;flattered@@ by your ";
             }
+            Output += this.GetAdjective("BODY", "Hips", hPercent) + " hips.";
+        }
 
-            return Output;
-        };
+        return Output;
+    };
 
     /**
      * Print out a description of the players Penis statistic.
@@ -518,7 +686,7 @@ App.PR = new function() {
             var iLength = this.CMtoINCH(Player.GetStat("BODY", "Penis"));
             if (typeof Arg !== 'undefined') return this.GetAdjective("BODY", "Penis", pPercent);
             return this.TokenizeRating(Player, "BODY", "Penis", this.GetRating("Penis", pPercent));
-        };
+		};
 
     /**
      * Prints out a description of the Player's height statistic.
@@ -570,10 +738,12 @@ App.PR = new function() {
      * @returns {XML|string|void}
      */
     this.pBust = function (Player, Arg) {
-            var bPercent = Player.GetStatPercent("BODY", "Bust");
-            if (typeof Arg !== 'undefined') return this.GetAdjective("BODY", "Bust", bPercent);
-            return this.TokenizeRating(Player, "BODY", "Bust", this.GetRating("Bust", bPercent));
-        };
+        var bPercent = Player.GetStatPercent("BODY", "Bust");
+        if (typeof Arg !== 'undefined') {
+            return this.GetAdjective("BODY", "Bust", bPercent);
+        }
+        return this.TokenizeRating(Player, "BODY", "Bust", this.GetRating("Bust", bPercent));
+    };
 
     /**
      * Print out a description of the Player's Bust (CUP) statistic.
@@ -748,28 +918,57 @@ App.PR = new function() {
      * @param {object} [Opt]
      * @returns {string}
      */
-    this.TokenizeString = function(Player, NPC, String, Opt)
-        {
-            if (typeof NPC !== 'undefined' ) {
-                String = String.replace(/NPC_NAME/g, NPC.pName());
-            }
+    this.TokenizeString = function(Player, NPC, String, Opt) {
+        if (typeof NPC !== 'undefined' ) {
+            String = String.replace(/NPC_NAME/g, NPC.pName());
+        }
 
-            String = String.replace(/PLAYER_NAME/g, "@@color:DeepPink;"+Player.SlaveName+"@@");
-            String = String.replace(/GF_NAME/g, "@@color:pink;"+Player.GirlfriendName+"@@");
-            String = String.replace(/pBUST/g, this.pBust(Player, 1));
-            String = String.replace(/pASS/g, this.pAss(Player, 1));
-            String = String.replace(/pCUP/g, this.pCup(Player));
-            String = String.replace(/pHIPS/g, this.pHips(Player, 1));
-            String = String.replace(/pLIPS/g, this.pLips(Player, 1));
-            String = String.replace(/pHORMONES/g, this.pHormones(Player, 1));
-            String = String.replace(/pBLOWJOBS/g, this.GetAdjective("SKILL", "BlowJobs", Player.GetStat("SKILL", "BlowJobs")));
-            String = String.replace(/pPHASE/g, Player.GetPhase(false));
-            String = String.replace(/pPENIS/g, this.pPenis(Player,1));
-            String = String.replace(/pWAIST/g, this.pWaist(Player, 1));
-            String = String.replace(/pFACE/g, this.pFace(Player, 1));
+        var _this = this;
+        function adjReplacer(match, stat) {
+            return _this.GetAdjective("BODY", stat, Player.GetStat("BODY", stat));
+        }
+        function nounReplacer(match, stat) {
+            return _this.GetPlayerNoun("BODY", stat, Player, false, true);
+        }
+        function pReplacer(match, prefix, stat, delim) {
+            // uppercase charachters following underscore (which is removed)
+            // STAT_NAME -> StatName
+            var statName = stat[0] + stat.slice(1).toLowerCase().replace(/_([a-z])/g, (m, c) => c.toUpperCase());
+            var statFuncName = 'p' + statName;
+            if (_this.hasOwnProperty(statFuncName))
+                return _this[statFuncName](Player, 1) + delim;
+            return prefix + stat + delim;
+        }
+        function nReplacer(match, prefix, stat, delim) {
+            // uppercase charachters following underscore (which is removed)
+            // STAT_NAME -> StatName
+            var statName = stat[0] + stat.slice(1).toLowerCase().replace(/_([a-z])/g, (m, c) => c.toUpperCase());
+            if (App.Data.Naming.BodyConfig.hasOwnProperty(statName))
+                return _this.GetPlayerNoun("BODY", statName, Player, true, true) + delim;
+            return prefix + stat + delim;
+        }
+        function vReplacer(match, prefix, stat, delim) {
+            // uppercase charachters following underscore (which is removed)
+            // STAT_NAME -> StatName
+            var statName = stat[0] + stat.slice(1).toLowerCase().replace(/_([a-z])/g, (m, c) => c.toUpperCase());
+            if (Player.GetStatObject("BODY").hasOwnProperty(statName))
+                return Player.GetStat("BODY", statName) + delim;
+            return prefix + stat + delim;
+        }
 
-            return String;
-        };
+        String = String.replace(/PLAYER_NAME/g, "@@color:DeepPink;"+Player.SlaveName+"@@");
+        String = String.replace(/GF_NAME/g, "@@color:pink;"+Player.GirlfriendName+"@@");
+        String = String.replace(/pCUP/g, this.pCup(Player)); // needs special handling because it has only a single parameter
+        String = String.replace(/NOUN_([A-Za-z_]+)/g, nounReplacer);
+        String = String.replace(/ADJECTIVE_([A-Za-z_]+)/g, adjReplacer);
+        String = String.replace(/pBLOWJOBS/g, this.GetAdjective("SKILL", "BlowJobs", Player.GetStat("SKILL", "BlowJobs")));
+        String = String.replace(/pPHASE/g, Player.GetPhase(false));
+        String = String.replace(/(p)([A-Z_]+)([^A-Za-z]|$)/g, pReplacer);
+        String = String.replace(/(n)([A-Z_]+)([^A-Za-z]|$)/g, nReplacer);
+        String = String.replace(/(v)([A-Z_]+)([^A-Za-z]|$)/g, vReplacer);
+
+        return String;
+    };
 
     this.pSkillName = function (Skill) {
         return App.Data.Lists["SkillDictionary"][Skill];

--- a/src/001-SCRIPT_DATA/GameData.js
+++ b/src/001-SCRIPT_DATA/GameData.js
@@ -133,6 +133,7 @@ App.Data.Lists = {
                 },
                 "Bust": { "MIN" : 0, "MAX" : 100, "START" : 0, "CM_MIN" : 80, "CM_MAX": 130,
                     "LEVELING" : {
+                        0 : { "COST" : 150, "STEP" : 1, "ADJECTIVE" : "flat",        "COLOR" :  1},
                         5 : { "COST" : 150, "STEP" : 1, "ADJECTIVE" : "swollen",     "COLOR" :  3},
                         8 : { "COST" : 150, "STEP" : 1, "ADJECTIVE" : "perky",       "COLOR" :  4},
                        11 : { "COST" : 175, "STEP" : 1, "ADJECTIVE" : "shapely",     "COLOR" :  5},
@@ -200,6 +201,25 @@ App.Data.Lists = {
                        88 : { "COST" : 525, "STEP" : 1, "ADJECTIVE" : "massive",     "COLOR" : 16},
                        94 : { "COST" : 550, "STEP" : 1, "ADJECTIVE" : "immense",     "COLOR" : 16},
                       100 : { "COST" : 575, "STEP" : 1, "ADJECTIVE" : "enormous",    "COLOR" : 16}
+                    }
+                },
+                "AssFirmness": {  "MIN" : 0, "MAX" : 100,
+                    "LEVELING" : {
+                        5 :   { "ADJECTIVE" : "flabby", "COLOR" :  1},
+                        10 :  { "ADJECTIVE" : "flabby", "COLOR" :  2},
+                        15 :  { "ADJECTIVE" : "flabby", "COLOR" :  3},
+                        20 :  { "ADJECTIVE" : "flabby", "COLOR" :  4},
+                        26 :  { "ADJECTIVE" : "flabby", "COLOR" :  5},
+                        32 :  { "ADJECTIVE" : "toned", "COLOR" :  6},
+                        38 :  { "ADJECTIVE" : "toned", "COLOR" :  7},
+                        46 :  { "ADJECTIVE" : "toned", "COLOR" :  8},
+                        54 :  { "ADJECTIVE" : "toned", "COLOR" :  9},
+                        62 :  { "ADJECTIVE" : "toned", "COLOR" : 10},
+                        71 :  { "ADJECTIVE" : "smooth and round", "COLOR" : 12},
+                        80 :  { "ADJECTIVE" : "smooth and round", "COLOR" : 13},
+                        89 :  { "ADJECTIVE" : "smooth and round", "COLOR" : 14},
+                        98 :  { "ADJECTIVE" : "smooth and round", "COLOR" : 15},
+                        100 : { "ADJECTIVE" : "smooth and round", "COLOR" : 16}
                     }
                 },
                 "Waist": { "MIN" : 0, "MAX" : 100, "START" : 46, "CM_MIN" : 40, "CM_MAX": 130,
@@ -1161,40 +1181,40 @@ App.Data.Ratings = {
                 44 : "You have ADJECTIVE LENGTH hips, perfect for grabbing a hold of when being fucked.",
                 49 : "You have ADJECTIVE LENGTH hips, perfect for grabbing a hold of when being fucked.",
                 54 : "You have ADJECTIVE LENGTH hips, perfect for grabbing a hold of when being fucked.",
-                59 : "You have ADJECTIVE LENGTH hips. They roll and undulate when you walk, shaking your ass.",
-                64 : "You have ADJECTIVE LENGTH hips. They roll and undulate when you walk, shaking your ass.",
-                70 : "You have ADJECTIVE LENGTH hips. They roll and undulate when you walk, shaking your ass.",
-                76 : "You have ADJECTIVE LENGTH hips. They sway back and forth, advertising your pASS ass for a good fuck.",
-                82 : "You have ADJECTIVE LENGTH hips. They sway back and forth, advertising your pASS ass for a good fuck.",
-                88 : "You have ADJECTIVE LENGTH hips. They sway back and forth, advertising your pASS ass for a good fuck.",
-                94 : "You have ADJECTIVE LENGTH hips. They sway back and forth constantly drawing attention to your pASS ass and practically begging for a good butt fuck.",
-               100 : "You have ADJECTIVE LENGTH hips. They sway back and forth constantly drawing attention to your pASS ass and practically begging for a good butt fuck."
+                59 : "You have ADJECTIVE LENGTH hips. They roll and undulate when you walk, shaking your NOUN_Ass.",
+                64 : "You have ADJECTIVE LENGTH hips. They roll and undulate when you walk, shaking your NOUN_Ass.",
+                70 : "You have ADJECTIVE LENGTH hips. They roll and undulate when you walk, shaking your NOUN_Ass.",
+                76 : "You have ADJECTIVE LENGTH hips. They sway back and forth, advertising your pASS NOUN_Ass for a good fuck.",
+                82 : "You have ADJECTIVE LENGTH hips. They sway back and forth, advertising your pASS NOUN_Ass for a good fuck.",
+                88 : "You have ADJECTIVE LENGTH hips. They sway back and forth, advertising your pASS NOUN_Ass for a good fuck.",
+                94 : "You have ADJECTIVE LENGTH hips. They sway back and forth constantly drawing attention to your pASS NOUN_Ass and practically begging for a good butt fuck.",
+               100 : "You have ADJECTIVE LENGTH hips. They sway back and forth constantly drawing attention to your pASS NOUN_Ass and practically begging for a good butt fuck."
             },
             "Ass": {
-                 0 : "Your ADJECTIVE ass looks emaciated and unhealthy.",
-                 1 : "You have a ADJECTIVE ass, it looks painful to sit on.",
-                 2 : "You have a ADJECTIVE ass, it looks painful to sit on.",
-                 3 : "Your ADJECTIVE butt looks almost hollow and unattractive.",
-                 5 : "Your ADJECTIVE butt looks almost hollow and unattractive.",
-                 8 : "You have a ADJECTIVE sized ass, neither too big or too small.",
-                11 : "You have a ADJECTIVE ass, it has a slight swell but nothing special.",
-                15 : "You have a pert ADJECTIVE ass that doesn't move in the slightest.",
-                19 : "You have an ADJECTIVE ass that does a good job of filling out a pair of panties.",
-                24 : "You have a ADJECTIVE ass that stretches sexily against your clothes.",
-                29 : "You have a ADJECTIVE ass that stretches sexily against your clothes.",
-                34 : "You have a ADJECTIVE ass, it's attractive enough to draw stares from men.",
-                39 : "You have a ADJECTIVE ass, it's attractive enough to draw stares from men.",
-                44 : "You have a ADJECTIVE ass that strains your bottoms and shakes when men slap it.",
-                49 : "You have a ADJECTIVE ass that strains your bottoms and shakes when men slap it.",
-                54 : "You have a ADJECTIVE ass that shakes and draws attention when you walk.",
-                59 : "You have a ADJECTIVE ass that shakes and draws attention when you walk.",
-                64 : "You have an ADJECTIVE ass that sways and jiggles sexily when you walk.",
-                70 : "You have a ADJECTIVE ass that gyrates back and forth when you strut your stuff.",
-                76 : "Your ADJECTIVE ass sensuously wobbles and jiggles at every minor movement, entrancing watchers.",
-                82 : "Your ADJECTIVE ass sensuously wobbles and jiggles at every minor movement, entrancing watchers.",
-                88 : "Your ADJECTIVE ass shakes and wobbles at the most minor movement of your pHIPS hips. Clothing can barely contain it and men lust after it.",
-                94 : "Your ADJECTIVE ass shakes and wobbles at the most minor movement of your pHIPS hips. Clothing can barely contain it and men lust after it.",
-               100 : "Your ADJECTIVE ass jiggles almost uncontrollably at the most minor prompting. A small slap sends off an 'butt quake' of jiggly ass flesh and men dream of fucking it."
+                 0 : "Your ADJECTIVE NOUN looks emaciated and unhealthy.",
+                 1 : "You have a ADJECTIVE NOUN, it looks painful to sit on.",
+                 2 : "You have a ADJECTIVE NOUN, it looks painful to sit on.",
+                 3 : "Your ADJECTIVE NOUN looks almost hollow and unattractive.",
+                 5 : "Your ADJECTIVE NOUN looks almost hollow and unattractive.",
+                 8 : "You have a ADJECTIVE sized NOUN, neither too big or too small.",
+                11 : "You have a ADJECTIVE NOUN, it has a slight swell but nothing special.",
+                15 : "You have a pert ADJECTIVE NOUN that doesn't move in the slightest.",
+                19 : "You have an ADJECTIVE NOUN that does a good job of filling out a pair of panties.",
+                24 : "You have a ADJECTIVE NOUN that stretches sexily against your clothes.",
+                29 : "You have a ADJECTIVE NOUN that stretches sexily against your clothes.",
+                34 : "You have a ADJECTIVE NOUN, it's attractive enough to draw stares from men.",
+                39 : "You have a ADJECTIVE NOUN, it's attractive enough to draw stares from men.",
+                44 : "You have a ADJECTIVE NOUN that strains your bottoms and shakes when men slap it.",
+                49 : "You have a ADJECTIVE NOUN that strains your bottoms and shakes when men slap it.",
+                54 : "You have a ADJECTIVE NOUN that shakes and draws attention when you walk.",
+                59 : "You have a ADJECTIVE NOUN that shakes and draws attention when you walk.",
+                64 : "You have an ADJECTIVE NOUN that sways and jiggles sexily when you walk.",
+                70 : "You have a ADJECTIVE NOUN that gyrates back and forth when you strut your stuff.",
+                76 : "Your ADJECTIVE NOUN sensuously wobbles and jiggles at every minor movement, entrancing watchers.",
+                82 : "Your ADJECTIVE NOUN sensuously wobbles and jiggles at every minor movement, entrancing watchers.",
+                88 : "Your ADJECTIVE NOUN shakes and wobbles at the most minor movement of your pHIPS hips. Clothing can barely contain it and men lust after it.",
+                94 : "Your ADJECTIVE NOUN shakes and wobbles at the most minor movement of your pHIPS hips. Clothing can barely contain it and men lust after it.",
+               100 : "Your ADJECTIVE NOUN jiggles almost uncontrollably at the most minor prompting. A small slap sends off an 'butt quake' of jiggly NOUN flesh and men dream of fucking it."
             },
             "Cup": {
                 0 : "Flat",
@@ -1223,48 +1243,48 @@ App.Data.Ratings = {
                 100 : "QQQ"
             },
             "Bust": {
-                0 : "Your chest is ADJECTIVE and unappealing.",
-                1 : "Your chest is ADJECTIVE and unappealing, it would barely fit an pCUP bra.",
-                2 : "You have ADJECTIVE tits that would fill out a pCUP bra.",
-                3 : "You have ADJECTIVE tits that would fill out a pCUP bra.",
-                5 : "You have ADJECTIVE tits that would fill out a pCUP bra, they sit high and firm.",
-                8 : "You have ADJECTIVE tits that would nicely fill out a pCUP bra.",
-                11 : "You have ADJECTIVE pCUP sized hooters, they slightly wobble and jiggle when you walk.",
-                15 : "You have ADJECTIVE pCUP sized jugs, they are fleshy, softy, jiggly and eye catching.",
-                19 : "You have ADJECTIVE pCUP sized funbags, they enticingly fill out your tops and jiggle sexily when you walk.",
-                24 : "You have ADJECTIVE pCUP sized tits, they enticingly fill out your tops and shimmy and quake when you walk.",
-                29 : "You have ADJECTIVE pCUP sized jugs, your overwhelming cleavage attracts lustful stares from men and they shake and wobble when you strut your stuff.",
-                34 : "You have ADJECTIVE pCUP sized boobies, your overwhelming cleavage attracts lustful stares from men and they jiggle and bounce when you strut your stuff.",
-                39 : "You have ADJECTIVE pCUP sized knockers, they wobble when you walk and your expansive cleavage attracts lustful stares from men.",
-                44 : "You have ADJECTIVE pCUP sized jugs, they wobble when you walk and your expansive cleavage attracts lustful stares from men.",
-                49 : "You have ADJECTIVE pCUP sized hooters, they wobble when you walk and your expansive cleavage attracts lustful stares from men.",
-                54 : "You have ADJECTIVE pCUP sized tits, they jiggle and shake constantly trying to escape your top.",
-                59 : "You have ADJECTIVE pCUP sized tits, they jiggle and shake constantly trying to escape your top.",
-                64 : "You have ADJECTIVE pCUP sized hooters, they spill out of your clothes and entice men to grope and grab them.",
-                70 : "You have ADJECTIVE pCUP sized funbags, they spill out of your clothes and entice men to grope and grab them.",
-                76 : "You have ADJECTIVE pCUP sized tits on your chest, they make every outfit you wear look obscene and men salivate at the thought of putting their cocks in between them.",
-                82 : "You have ADJECTIVE pCUP sized jugs on your chest, they make every outfit you wear look obscene and men salivate at the thought of putting their cocks in between them.",
-                88 : "You have ADJECTIVE pCUP sized fuck bags on your chest, you mostly have given up trying to cover them because they'll wobble and shake free of anything at the slightest provocation.",
-                94 : "Your ADJECTIVE pCUP sized tits make it known to everyone that you're a total fuck slut ready for sex. They shake and jiggle at the slightest motion and spill out of your top every couple of minutes.",
-               100 : "Your ADJECTIVE pCUP sized tits make it known to everyone that you're a total fuck slut ready for sex. They shake and jiggle at the slightest motion and spill out of your top every couple of minutes. When you eat, you place them on the table to avoid back strain and you have to sleep on your side or you'll suffocate."
-            },
+                0 : "Your NOUN is ADJECTIVE and unappealing.",
+                1 : "Your NOUN is ADJECTIVE and unappealing, it would barely fit an pCUP bra.",
+                2 : "You have ADJECTIVE NOUN that would fill out a pCUP bra.",
+                3 : "You have ADJECTIVE NOUN that would fill out a pCUP bra.",
+                5 : "You have ADJECTIVE NOUN that would fill out a pCUP bra, they sit high and firm.",
+                8 : "You have ADJECTIVE NOUN that would nicely fill out a pCUP bra.",
+                11 : "You have ADJECTIVE pCUP sized NOUN, they slightly wobble and jiggle when you walk.",
+                15 : "You have ADJECTIVE pCUP sized NOUN, they are fleshy, softy, jiggly and eye catching.",
+                19 : "You have ADJECTIVE pCUP sized NOUN, they enticingly fill out your tops and jiggle sexily when you walk.",
+                24 : "You have ADJECTIVE pCUP sized NOUN, they enticingly fill out your tops and shimmy and quake when you walk.",
+                29 : "You have ADJECTIVE pCUP sized NOUN, your overwhelming cleavage attracts lustful stares from men and they shake and wobble when you strut your stuff.",
+                34 : "You have ADJECTIVE pCUP sized NOUN, your overwhelming cleavage attracts lustful stares from men and they jiggle and bounce when you strut your stuff.",
+                39 : "You have ADJECTIVE pCUP sized NOUN, they wobble when you walk and your expansive cleavage attracts lustful stares from men.",
+                44 : "You have ADJECTIVE pCUP sized NOUN, they wobble when you walk and your expansive cleavage attracts lustful stares from men.",
+                49 : "You have ADJECTIVE pCUP sized NOUN, they wobble when you walk and your expansive cleavage attracts lustful stares from men.",
+                54 : "You have ADJECTIVE pCUP sized NOUN, they jiggle and shake constantly trying to escape your top.",
+                59 : "You have ADJECTIVE pCUP sized NOUN, they jiggle and shake constantly trying to escape your top.",
+                64 : "You have ADJECTIVE pCUP sized NOUN, they spill out of your clothes and entice men to grope and grab them.",
+                70 : "You have ADJECTIVE pCUP sized NOUN, they spill out of your clothes and entice men to grope and grab them.",
+                76 : "You have ADJECTIVE pCUP sized NOUN on your chest, they make every outfit you wear look obscene and men salivate at the thought of putting their cocks in between them.",
+                82 : "You have ADJECTIVE pCUP sized NOUN on your chest, they make every outfit you wear look obscene and men salivate at the thought of putting their cocks in between them.",
+                88 : "You have ADJECTIVE pCUP sized NOUN on your chest, you mostly have given up trying to cover them because they'll wobble and shake free of anything at the slightest provocation.",
+                94 : "Your ADJECTIVE pCUP sized NOUN make it known to everyone that you're a total fuck slut ready for sex. They shake and jiggle at the slightest motion and spill out of your top every couple of minutes.",
+               100 : "Your ADJECTIVE pCUP sized NOUN make it known to everyone that you're a total fuck slut ready for sex. They shake and jiggle at the slightest motion and spill out of your top every couple of minutes. When you eat, you place them on the table to avoid back strain and you have to sleep on your side or you'll suffocate."
+           },
             "Lips": {
-                  0: "ADJECTIVE lips like an old person or a zombie.",
-                  5: "ADJECTIVE lips like an old person or a zombie.",
-                 10: "ADJECTIVE lips that look unappealing and harsh.",
-                 15: "ADJECTIVE lips that look dry and parched.",
-                 20: "ADJECTIVE, masculine lips that are rather unappealing.",
-                 26: "ADJECTIVE, slightly masculine lips that are slightly chapped.",
-                 32: "ADJECTIVE and moist, slightly feminine lips.",
-                 38: "ADJECTIVE, almost girlish lips.",
-                 46: "ADJECTIVE, girly lips with a cute pout.",
-                 54: "ADJECTIVE, womanly lips with an enticing smile.",
-                 62: "ADJECTIVE, kissable lips in a classic bow shape.",
-                 71: "ADJECTIVE lips like those on an air-headed bimbo.",
-                 80: "ADJECTIVE lips, almost comical in appearance. They look good wrapped around a cock.",
-                 89: "ADJECTIVE lips that are so fat your mouth is in a perpetual 'o' shape, just waiting for a dick.",
-                 98: "ADJECTIVE lips, they are always partway open and wet with your saliva. They make your face look like a sissy fuckhole.",
-                100: "ADJECTIVE lips, so enormous that they look like a pair of pillows made for sucking cock. They cause you to speak with a pronounced lisp and they're always so wet with your saliva that you often find yourself constantly wiping your own drool from your pBUST tits."
+                  0: "ADJECTIVE NOUN like an old person or a zombie.",
+                  5: "ADJECTIVE NOUN like an old person or a zombie.",
+                 10: "ADJECTIVE NOUN that look unappealing and harsh.",
+                 15: "ADJECTIVE NOUN that look dry and parched.",
+                 20: "ADJECTIVE, masculine NOUN that are rather unappealing.",
+                 26: "ADJECTIVE, slightly masculine NOUN that are slightly chapped.",
+                 32: "ADJECTIVE and moist, slightly feminine NOUN.",
+                 38: "ADJECTIVE, almost girlish NOUN.",
+                 46: "ADJECTIVE, girly NOUN with a cute pout.",
+                 54: "ADJECTIVE, womanly NOUN with an enticing smile.",
+                 62: "ADJECTIVE, kissable NOUN in a classic bow shape.",
+                 71: "ADJECTIVE NOUN like those on an air-headed bimbo.",
+                 80: "ADJECTIVE NOUN, almost comical in appearance. They look good wrapped around a cock.",
+                 89: "ADJECTIVE NOUN that are so fat your mouth is in a perpetual 'o' shape, just waiting for a dick.",
+                 98: "ADJECTIVE NOUN, they are always partway open and wet with your saliva. They make your face look like a sissy fuckhole.",
+                100: "ADJECTIVE NOUN, so enormous that they look like a pair of pillows made for sucking cock. They cause you to speak with a pronounced lisp and they're always so wet with your saliva that you often find yourself constantly wiping your own drool from your pBUST tits."
             },
             "Style": {
                  0: "repulsive, like a homeless person",
@@ -1339,6 +1359,77 @@ App.Data.Ratings = {
                 100: "ADJECTIVE, with an iron constitution and powerful pHORMONES muscles, the apex of physical perfection."
             }
         };
+
+App.Data.Naming = {
+    "BodyConfig": {
+        "Face": { "NOUN": "face" },
+        "Hair": { "NOUN": "hair" },
+        "Lips": {
+            "NOUN" : {
+                "LEVELING" : {
+                    0   : "lips",
+                    100 : "cock pillows"
+                }
+            }
+        },
+        "Bust": {
+            "ADJECTIVE": {
+                "APPLICABLE_LEVEL" : [{ "MIN" : 0, "MAX" : 100 }],
+                "RATING": [ "BODY/Bust" ],
+            },
+            "NOUN" : {
+                "INDEX": [ "BODY/Bust" ],
+                "LEVELING" : {
+                    0   : "chest",
+                    3   : "tits",
+                    11  : "hooters",
+                    15  : "jugs",
+                    19  : "funbags",
+                    24  : "tits",
+                    29  : "jugs",
+                    34  : "boobies",
+                    39  : "knockers",
+                    44  : "jugs",
+                    49  : "hooters",
+                    54  : "tits",
+                    64  : "hooters",
+                    70  : "funbags",
+                    76  : "tits",
+                    88  : "fuck bags",
+                    94  : "tits",
+                    100 : "melons"
+                }
+            }
+        },
+        "Ass" : {
+            "ADJECTIVE": {
+                "RATING": [ "BODY/Ass", "BODY/AssFirmness" ],
+                "INDEX" : [ "BODY/Ass", "STAT/Fitness" ],
+                "APPLICABLE_LEVEL" : [{ "MIN" : 0, "MAX" : 100 }, { "MIN" : 10, "MAX" : 100 }],
+            },
+            "NOUN": {
+                "INDEX": ["BODY/Ass", "STAT/Fitness"],
+                "LEVELING": {
+                    0   : "ass",
+                    100 : "ass"
+                }
+            }
+        },
+        "Hips" : { "NOUN" : "hips"},
+        "Waist" : { "NOUN" : "waist"},
+        "Penis" : {
+            "NOUN" : {
+                "LEVELING": {
+                    0   : "sissy clit",
+                    10  : "over sized sissy clit",
+                    25  : "dick",
+                    66  : "cock",
+                    100 : "tool"
+                }
+            },
+        }
+    }
+};
 
 App.Data.Enemies = {
   "PIRATE_A" : {


### PR DESCRIPTION
This gives possibility to put placeholders for body part names that expands into  leveled nouns. The nouns can depend on any number of any levelling stats.

Also adds new placeholders for App.PR.TokenizeString():
- NOUN_([A-Za-z_]+) for substitutting with leveled noun. Example:
NOUN_Ass.

- ADJECTIVE_([A-Za-z_]+) for leveled adjective (ADJECTIVE_Ass).

- p([A-Z_]+) for description for any pXXX function in App.PR
(pBust).

- n([A-Z_]+) for full noun expansion with all applicable
adjectives.

- v([A-Z_]+) for outputting numerical value of the given statistics.
Could be usefull in twine conditionals.

To illustrate how do we define those nouns and what output do we get, consider the following members of the new `App.Data.Naming` namespace:
```json
"Bust": {
      "ADJECTIVE": {
          "APPLICABLE_LEVEL" : [{ "MIN" : 0, "MAX" : 100 }],
          "RATING": [ "BODY/Bust" ],
       },
       "NOUN" : {
           "INDEX": [ "BODY/Bust" ],
           "LEVELING" : {
                    0   : "chest",
                    3   : "tits",
                    11  : "hooters",
                    15  : "jugs",
                    19  : "funbags",
                    24  : "tits",
                    29  : "jugs",
                    34  : "boobies",
                    39  : "knockers",
                    44  : "jugs",
                    49  : "hooters",
                    54  : "tits",
                    64  : "hooters",
                    70  : "funbags",
                    76  : "tits",
                    88  : "fuck bags",
                    94  : "tits",
                    100 : "melons"
         }
     }
}
```

The entry for bust declares that a noun to describe bust is leveled with "BODY/Bust" stat, that it is accompanied by an adjective, which shall be read from BODY/Bust rating table, and that the adjective is applicable for bust sizes from 0 to 100.

Then the mirror would tell "You have sizable E cup sized jugs…" or "You have flat chest" (yeah, there is no article there :().

The next example:
```json
 "Ass" : {
     "ADJECTIVE": {
           "RATING": [ "BODY/Ass", "BODY/AssFirmness" ],
           "INDEX" : [ "BODY/Ass", "STAT/Fitness" ],
           "APPLICABLE_LEVEL" : [{ "MIN" : 0, "MAX" : 100 }, { "MIN" : 10, "MAX" : 100 }],
      },
      "NOUN": {
          "INDEX": ["BODY/Ass"],
          "LEVELING": {
              0   : "ass",
            100 : "ass"
          }
     }
 },
```
This declares noun for ass, which is accompanied by two adjectives. The first one is read from BODY/Ass leveling table and is applicable to the whole range of ass sizes (as in the example above). The second rating is read from BODY/AssFirmness rating table using the value of STAT/Fitness and is applicable for asses of size 10 or more.

Example output:
```js
App.PR.TokenizeString(SugarCube.setup.player, undefined, "nASS")
"@@color:#3A01DF;hefty@@ @@color:#01DFD7;toned@@ @@color:#3A01DF;ass@@"

App.PR.TokenizeString(SugarCube.setup.player, undefined, "NOUN_Ass")
"@@color:#3A01DF;ass@@"

App.PR.TokenizeString(SugarCube.setup.player, undefined, "ADJECTIVE_Ass")
"@@color:#3A01DF;hefty@@"
```  