### PR TITLE
Add a quest to unlock inventory favorites. Closes #99.

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -477,7 +477,7 @@ App.PR = new function() {
      * @param {App.Entity.Player} Player
      * @param {string} NPC - String, ID of the NPC in Player.NPCS array.
      */
-        this.pQuestDialog = function(QuestID, Stage, Player, NPC) { return this.TokenizeString(Player, NPC, App.Data.Quests[QuestID][Stage]); };
+    this.pQuestDialog = function(QuestID, Stage, Player, NPC) { return this.TokenizeString(Player, NPC, App.Data.Quests[QuestID][Stage]); };
 
     /**
      * Prints out the requirements for completion of a quest.
@@ -511,7 +511,6 @@ App.PR = new function() {
                 switch (checks[i]["TYPE"]) {
                     case "FLAG":
                         continue;
-                        break;
                     case "NPC_MOOD":
                         bMeter = true;
                         Val = Player.GetNPC(Name).Mood();
@@ -574,6 +573,11 @@ App.PR = new function() {
                         var count = Player.GetHistory("CUSTOMERS", Name);
                         Val = (count - flag >= checks[i]["VALUE"]);
                         pString = "Satisfy Customers "+(count-flag)+"/"+checks[i]["VALUE"];
+                        break;
+                    case "TRACK_PROGRESS":
+                        bMeter = true;
+                        Val = App.QuestEngine.GetProgressValue(Player, Name);
+                        pString = "Progress";
                         break;
                 }
 
@@ -1003,6 +1007,28 @@ App.PR = new function() {
      */
     this.GetItemFavoriteIcon = function (IsFavorite) {
         return IsFavorite ? "@@color:yellow;&#9733;@@" : "@@color:white;&#9734;@@";
+    };
+
+
+    /**
+     * Get random item from inventory
+     * @param {App.Entity.Player} Player
+     * @returns {string}
+     */
+    this.GetRandomItemId = function(Player) {
+        var itemTypeCount = Player.InventoryItemsCount();
+        var randomIndex = Math.floor(Math.random() * itemTypeCount);
+        var id = "";
+        Player.InventoryManager.EveryItemRecord(undefined, undefined,
+            function(n, tag, itemClass) {
+                if (randomIndex <= 0) {
+                    id = App.Item.MakeId(itemClass, tag);
+                    return false;
+                }
+                randomIndex -= n;
+                return true;}
+        );
+        return id;
     };
 
     this.RefreshTwineMoney = function() {

--- a/src/001-SCRIPT_DATA/QUESTS/julius_quests.js
+++ b/src/001-SCRIPT_DATA/QUESTS/julius_quests.js
@@ -12,15 +12,15 @@ App.Data.Quests["BETTER_BED"] = {
     ],
     "REWARD": [
     ],
-    "INTRO": 
+    "INTRO":
         "NPC_NAME twitches nervously and looks around even though it's obvious only the two of you are in the room. He starts to speak but stops to look around again. Finally, he says, \"Okay, PLAYER_NAME, I actually can get you a better bunk for your room. But you have to do something for me first.\"\n\n"+
         "You roll your eyes. Of course no one wants to just fuckin' //help// on this blasted boat! You sigh and nod to him in resignation.\n\n"+
         "He smiles and raises his hands to his chest to twiddle his fingers together in excitement. \"I've been working on a new liniment -- a bona fide breakthrough! -- and you're going to help me test it. Come see me tomorrow <<if setup.player.Equipment['Shoes'] neq 0>>and make sure you're ''barefoot''.<<else>>but don't put on shoes before then.<</if>>\""+
         "<<set setup.player.QuestFlags.JULIUS_DATE to (setup.player.Day + 1)>>",
-    "MIDDLE": 
+    "MIDDLE":
         "NPC_NAME says in clear agitation, \"I said to wait and come back ''barefoot'', PLAYER_NAME! It's not that hard, ya ditzy nympho!\" He looks surprised at his own words and then, after making sure no one else is around, he quietly adds, \"Just... start paying attention, how about?\"\n\n"+
         "You frown at being called a 'nympho' since you obviously didn't choose this life and you're getting fucked whether you want it or not, but you don't see any point in arguing with him.",
-    "FINISH": 
+    "FINISH":
         "NPC_NAME looks over your shoulder to make sure no one else is with you when you approach. \"Okay,\" he says, \"sit down in the corner over here. Feet up on this.\" He smacks a bucket beside him as he kneels down in front of you.\n\n"+
         "You prop your bare feet up as requested and he immediately douses them with a warm, gooey liquid. //Ugh no... that can't be cum, right?//\n\n"+
         "He starts massaging your feet, squishing the goo between your toes and smearing it all over up to your ankles. Honestly it doesn't feel bad... just kind of gross. Especially so because there's an unsightly ferret-looking guy doing it and he's obviously enjoying himself.\n\n"+
@@ -28,9 +28,9 @@ App.Data.Quests["BETTER_BED"] = {
         "You wiggle your toes and wait for him to come back. Whatever that ooze was, it has definitely had some sort of effect. Your feet feel silky when you rub them against each other even though the gunk has completely dried and they're looking noticeably more... @@color:pink;feminine@@.\n\n"+
         "NPC_NAME hurries back into the cargo hold, shoots you a thumbs-up, and says \"You're all set, PLAYER_NAME.\"\n\n"+
         "You stand up. Oddly, it seems as if you can feel the slightest details of the warped wood underneath your bare feet. You shrug it off as your imagination.",
-    "JOURNAL_ENTRY" : 
+    "JOURNAL_ENTRY" :
         "NPC_NAME has promised to get you a more comfortable bed if you come back later without shoes for some reason... and probably not a good one.",
-    "JOURNAL_COMPLETE" : 
+    "JOURNAL_COMPLETE" :
         "Surprisingly, NPC_NAME actually followed through with his promise and somehow managed to get your cot replaced with a much more comfortable bunk. All it cost you was a little dignity -- the same as everything else costs you around here, it seems."
 };
 App.Data.Quests["CABIN_DECORATION"] = {
@@ -48,16 +48,16 @@ App.Data.Quests["CABIN_DECORATION"] = {
     ],
     "REWARD": [
     ],
-    "INTRO": 
+    "INTRO":
         "NPC_NAME waits for the other sailor in the cargo hold -- a burly bastard you've sucked off two or three times before but couldn't guess the name of for the life of you -- to leave before even acknowledging your existence.\n\n"+
         "\"So you want some gimcrack and gewgaw to spruce up your cabin, huh PLAYER_NAME?\" he asks, smirking weasily. \"Of course I can help!\" He looks around. \"//After// you help me.\"\n\n"+
         "You sigh and nod, very used to the game of give-and-take aboard this scabrous ship by now.\n\n"+
         "\"Same as before, come back tomorrow -- barefoot, of course. I've revised the liniment formula and we need to test it.\" He shoots you a conspiratorial wink and then shoos you away.\n\n"+
         "<<set setup.player.QuestFlags.JULIUS_DATE to (setup.player.Day + 1)>>",
-    "MIDDLE": 
+    "MIDDLE":
         "NPC_NAME says in clear agitation, \"I said to wait and come back ''barefoot'', PLAYER_NAME! Why do you keep being so thick, ya damned doofy butt-slut?\"\n\n"+
         "You roll your eyes at being called a 'butt-slut' but yet again you don't see any point in arguing with him.",
-    "FINISH": 
+    "FINISH":
         "NPC_NAME looks over your shoulder to make sure no one else is with you when you approach. \"Okay,\" he says, \"you remember: sit down in the corner over here. Feet up on this.\" He smacks a bucket beside him as he kneels down in front of you.\n\n"+
         "You prop your bare feet up as requested and he immediately douses them with a warm, gooey liquid just as before.\n\n"+
         "Once again he starts massaging your feet, squishing the goo between your toes and smearing it all over up to your ankles. It almost feels nice... but you really wish he wasn't enjoying it so much.\n\n"+
@@ -67,9 +67,9 @@ App.Data.Quests["CABIN_DECORATION"] = {
         "You look down at your jizz-painted feet and sigh. You thought you were pretty knowledgeable about all the ways to coax cum from a cock but it's clear you still have some things to learn. The gooey cock-spew starts to get lumpy and sticky on your feet as it cools but the sensation isn't icky at all. Which is concerning. As is the impression that your feet have somewhat taken on a @@color:pink;girlish@@ contour and softness.\n\n"+
         "Finally, NPC_NAME bustles back into the cargo hold. He shoots you a thumbs-up just like he did the time before and once again says \"You're all set, PLAYER_NAME.\"\n\n"+
         "You stand up and this time you're sure the bottoms of your bare feet feel more sensitive on the warped wood of the floor. You scrunch your toes against the grain and the sensation sends a shiver up your spine. You shake your head, hoping that the weird sensitivity doesn't last much longer.",
-    "JOURNAL_ENTRY" : 
+    "JOURNAL_ENTRY" :
         "NPC_NAME has promised to get you some decoration for your cabin if you come back later without shoes again.",
-    "JOURNAL_COMPLETE" : 
+    "JOURNAL_COMPLETE" :
         "Once again, NPC_NAME actually followed through with his promise and somehow managed to get a nice bright lantern for your room and a couple picturesque -- if not obscene -- paintings for your walls. All it cost you was a little more dignity and enduring a new form of sexual abuse."
 };
 
@@ -90,17 +90,17 @@ App.Data.Quests["CABIN_RUG"] = {
     "REWARD": [
         {"REWARD_TYPE": "ITEM", "TYPE": "CLOTHES", "NAME": "barefoot sandals", "AMOUNT": 1},
     ],
-    "INTRO": 
+    "INTRO":
         "You patiently wait for NPC_NAME to finish his skittish surveillance of the cargo hold before you approach. He flagrantly eyes your bare feet while licking his tongue across his parched lips and his trousers tent with impressive rapidity.\n\n"+
         "\"Back for more, huh PLAYER_NAME?\" he asks. His eyes go shifty for a few moments and he whispers to you, \"Keep this between the two of us... I have //perfected// the liniment.\"\n\n"+
         "You nod at him as if you care about his nasty spunk-salve.\n\n"+
         "\"You know the deal, sweetfeet. Come back tomorrow prepared to test the liniment and I will see about securing you a patch of carpet in your cabin for your tender footsies.\" He grins and wiggles his eyebrows.\n\n"+
         "Again you nod. With a satisfied simper, he gestures for you to scram."+
         "<<set setup.player.QuestFlags.JULIUS_DATE to (setup.player.Day + 1)>>",
-    "MIDDLE": 
+    "MIDDLE":
         "NPC_NAME stares at you, his weak jaw clenched tight. \"You are the dumbest dingbat I've ever met, PLAYER_NAME. Wait. And. Come. Back. Barefoot. You. Silly. Cock-sock.\"\n\n"+
         "You snort at the term juvenile 'cock-sock' but once more you don't see any point in arguing with him.",
-    "FINISH": 
+    "FINISH":
         "NPC_NAME scans the area and excitedly beckons for you to approach. \"Sit down in the corner already! Feet up!\" He smacks a bucket beside him as he kneels down in front of you.\n\n"+
         "You prop your bare feet up yet again and he immediately douses them with a warm, gooey liquid for the third time.\n\n"+
         "His fingers squish between your toes and knead against your soles. Like the times before, it isn't exactly unpleasant -- but unlike the times before, you soon find yourself squirming in your seat and worrying to yourself about how suddenly aroused you feel.\n\n"+
@@ -112,8 +112,48 @@ App.Data.Quests["CABIN_RUG"] = {
         "Finally, NPC_NAME bustles back into the cargo hold. He shoots you a thumbs-up just like he has done every time before and once again says \"You're all set, PLAYER_NAME.\"\n\n"+
         "You stand up and you have no doubt at all that the bottoms of your bare feet feel more sensitive on the warped wood of the floor. Your whole body trembles in delight at the scintillating sensations underfoot. You have to steady yourself with a hand on the bulkhead and take short breaths to calm yourself.\n\n"+
         "NPC_NAME smirks at you and says, \"Told you it was perfected.\" He drops some fine @@color:orange;dangling silver chains@@ into your free hand and winks. \"I think you'll like those.\"",
-    "JOURNAL_ENTRY" : 
+    "JOURNAL_ENTRY" :
         "NPC_NAME has promised to get you a rug for your cabin to help assuage the distracting sensitivity of your feet if you come back later without shoes again.",
-    "JOURNAL_COMPLETE" : 
+    "JOURNAL_COMPLETE" :
         "Once again, NPC_NAME actually followed through with his promise and somehow managed to get a plush rug for your cabin floor. All it cost you was more dignity and another round of fetishy foot ravishment."
+};
+
+App.Data.Quests["BETTER_LOCKER"] = {
+    "ID": "BETTER_LOCKER", "Title": "Clean up the locker",
+    "GIVER": "Quartermaster",
+    "PRE": [
+        { "TYPE" : "QUEST_FLAG", "NAME" : "BETTER_LOCKER_REQUIRED", "VALUE" : true }
+    ],
+    "ON_ACCEPT" : [
+        { "TYPE" : "TRACK_PROGRESS", "NAME" : "JuliusHandwork" }
+    ],
+    "CHECKS": [
+        { "TYPE": "TRACK_PROGRESS",  "NAME": "JuliusHandwork", "VALUE" : 1.0}
+    ],
+    "POST": [
+        { "TYPE" : "QUEST_FLAG", "NAME" : "BETTER_LOCKER_REQUIRED", "OPT" : "DELETE" },
+    ],
+    "REWARD": [
+    ],
+    "INTRO":
+        "NPC_NAME is the person who can help you with your locker, you guess. \"Probably, NPC_NAME could make boxes or shelves for my locker so I could store my items in organized way\", you think\n\
+        You approach him and in kindness words you can ask him to solve your locker problem. To your surprise, NPC_NAME agrees.\
+        \"Wanna be special, huh?\" says NPC_NAME. \"Yes, I can help you. Boxes, you say? Well, I could make the boxes. If I will be in a mood, you know...\"\n\
+        That sounds promising, and you ask him does he mean any particular mood.\n\
+        \"Just a good enough mood.\" NPC_NAME replies \"You keep me happy and I make the boxes for you in my free time. Deal?",
+    "MIDDLE":
+        "\"Don't try to push me, PLAYER_NAME.\" says NPC_NAME. \"It will be ready when it comes. You'd better take care of your part of the deal, PLAYER_NAME\"",
+    "ON_DAY_PASSED": function(Player) {
+        var npcMood = Player.GetNPC(this.GIVER).Mood();
+        // at highest mood this should take 7 days, but if mood is lower than 60 (Satisfied), Julius re-uses already done items for other means
+        App.QuestEngine.SetProgressValue(SugarCube.setup.player, "JuliusHandwork",
+            Math.clamp(App.QuestEngine.GetProgressValue(SugarCube.setup.player, "JuliusHandwork") + (npcMood - 60)/7/40., 0., 1.));
+    },
+    "FINISH":
+        "\"Okay, PLAYER_NAME, here is your stuff.\" NPC_NAME handles you a set of not that ugly looking wooden boxes, crates and caskets. \"I've made them of various sizes so you can keep your junk well sorted, ha-ha!\"\n\
+        You are happy to find that they suit your needs and that finally brings in the order your locker was  crying for recently so badly.",
+    "JOURNAL_ENTRY" :
+        "NPC_NAME has promised to make a number of boxes for your locker. Hopefully that will help you to organize your belongins.",
+    "JOURNAL_COMPLETE" :
+        "Once again, NPC_NAME actually followed through with his promise and somehow constructed nice boxes of different sizes that perfectly fit in your locker and into each other. The boxes will certainly help you to keep your stuff organized and easily accessible."
 };

--- a/src/200-WIDGETS/InventoryWidgets.twee
+++ b/src/200-WIDGETS/InventoryWidgets.twee
@@ -67,7 +67,7 @@
 	</tr>
 	<tr>
 		<td style="width:670px;">
-			You moved <<= _Item.Description;>> to the <<if _Item.ToggleFavorite()>>top<<else>>bottom<</if>> of your locker.</td>
+			You placed <<= _Item.Description();>> <<if _Item.ToggleFavorite()>>in a special box<<else>>back to the comon locker space<</if>>.</td>
 	</tr>
 </tbody>
 </table><<replace "#PlayerScore">><<score>><</replace>><</widget>>
@@ -98,6 +98,7 @@
 <</nobr>><</widget>>
 
 <<widget "InventoryTable">><<nobr>>
+<<set _favoritesEnabled = App.QuestEngine.QuestCompleted(setup.player, "BETTER_LOCKER");>>
 <<run App.PR.HighlightActiveTabButton($args[1], $args[0], "Inventory - " +  $args[2])>>
 <<switch $args[0]>>
 <<case "food">>
@@ -125,7 +126,7 @@
 </tr>
 <<for _i = 0; _i lt _Items.length; _i++>>
 <tr>
-<td><<= "<<FavoriteItemButton \"" + _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >></td>
+<td><<if _favoritesEnabled>><<= "<<FavoriteItemButton \""+ _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >> <</if>></td>
 <td><<= _Items[_i].Charges() >></td>
 <td style="text-align:left"><<= "<<ThrowItemButton \"" + _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >></td>
 <td><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>
@@ -173,7 +174,7 @@
 </tr>
 <<for _i = 0; _i lt _Items.length; _i++>>
 <tr>
-<td><<= "<<FavoriteItemButton \""+ _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >></td>
+<td><<if _favoritesEnabled>><<= "<<FavoriteItemButton \""+ _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >> <</if>></td>
 <td><<= _Items[_i].Charges() >></td>
 <td style="text-align:left"><<= "<<ThrowItemButton \"" + _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >></td>
 <td><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>
@@ -193,7 +194,7 @@
 </tr>
 <<for _i = 0; _i lt _Items.length; _i++>>
 <tr>
-<td><<= "<<FavoriteItemButton \""+ _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >></td>
+<td><<if _favoritesEnabled>><<= "<<FavoriteItemButton \""+ _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >> <</if>></td>
 <td><<= _Items[_i].Charges() >></td>
 <td style="text-align:left"><<if _Items[_i].Type == "LOOT_BOX">><<= "<<ThrowItemButton \"" + _Items[_i].Id + "\" \"" + $args[0] + "\" >>" >><</if>></td>
 <td><<= App.PR.PrintItem(_Items[_i], setup.player) >></td>

--- a/src/201-UI/Inventory.twee
+++ b/src/201-UI/Inventory.twee
@@ -2,7 +2,26 @@
 @@color:cyan;Interact@@: <<click "Exit" $GameBookmark>><</click>>\
 <<set _Drugs = setup.player.GetItemByTypes(["potion"]);>>\
 <<set _Quests = setup.player.GetItemByTypes(["QUEST", "LOOT_BOX"]);>>
-
+\
+<<if !App.QuestEngine.QuestCompleted(setup.player, "BETTER_LOCKER") && (setup.player.InventoryItemsTypes() > 50 || setup.player.InventoryItemsCount() > 250)>>
+	<<run App.QuestEngine.SetQuestFlag(setup.player, "BETTER_LOCKER_REQUIRED", true)>>\
+<</if>>\
+<<if App.QuestEngine.GetQuestFlag(setup.player, "BETTER_LOCKER_REQUIRED")>>\
+Your locker is so full of <<if setup.player.InventoryItemsTypes() > 50>>various <</if>> items, that it became hard to find anything in it.
+<<if setup.player.InventoryItemsCount() > 500>>\
+<<set _itemId to App.PR.GetRandomItemId(setup.player)>>\
+<<set _itemLost to setup.player.GetItemById(_itemId)>>\
+<<set _lostCharges to Math.floor(Math.random() * _itemLost.Charges() * 0.25)>>\
+<<if _lostCharges > 0>>\
+Probably due to the mess in your locker you can't find all of your stuff anymore. You just realized \
+<<if _lostCharges === 1>>that @@color:red;you managed to lose@@ <<else>><<=_lostCharges>> items of <<=_itemLost.Name>> \
+@@color:red;gone missing@@<</if>>!
+<<run _itemLost.AddCharges(0-_lostCharges)>>\
+<</if>>\
+<</if>>\
+You need to to orginize your locker space. Probably, the only person on board who can help you is <<= setup.player.GetNPC("Quartermaster").pName()>>.<br>
+<</if>>\
+\
 <span class="tabbar" id="InventoryTabs">\
 	@@.activeTabCaption;<span>placeholder</span>@@\
 	@@.tablink;#misc;<<button "Misc">>\


### PR DESCRIPTION
The gameplay gets the following changes: when inventory contains too
many items (>250) or too many items types (>50), players get a
message about that when opening inventory. Additionally, when number of
items is > 500, on each opening some items get lost (up to 25% of the
randomly selected item, accounting for items charges. I.e. the items
with most charges will be most likely lost). When player complete a
quest with Julius, favorites button is enabled and the messages do not
pop up anymore.