### PR TITLE
Refactor inventory tabs and add tabs to the journal.

### DIFF
--- a/src/000-SCRIPT_OBJ/EventHandlers.js
+++ b/src/000-SCRIPT_OBJ/EventHandlers.js
@@ -211,6 +211,17 @@ App.EventHandlers = new function() {
             delete save.state.history[0].variables.Player; // Clear old player object after copy.
         }
 
+        if (save.version < 0.09) {
+            console.log("Adding empty game stat records...");
+            save.state.history[0].variables.PlayerState.GameStats = {
+                "MoneyEarned":      0,
+                Skills : { }
+            };
+            for (var skill in save.state.history[0].variables.PlayerState.Skills) {
+                if (!save.state.history[0].variables.PlayerState.Skills.hasOwnProperty(skill)) continue;
+                save.state.history[0].variables.PlayerState.GameStats.Skills[skill] = {"Failure": 0, "Success": 0};
+            }
+        }
 
         if (save.version > App.Data.Game.Version) {
             /* Invalidates saves outside of legal scope */

--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -1048,6 +1048,48 @@ App.PR = new function() {
         }
         return res;
     };
+
+    /**
+     * Highlight active button in a tabbar
+     *
+     * Finds the active element and appends " active" to its style, removing " active" from all
+     * other children of the tabbar.
+     * @param {string} tabbarId  Id of the tab bar element
+     * @param {string} activeButtonId Id of the button for the active tab
+     * @param {string} activeTabText Text to set for .activeTabCaption children of the tab bar
+     *
+     * @example <div id="tabbar">
+     *  <span class="activeTabCaption">placeholder text</span>
+     *  <span class="tablink" id="btn1"><button class="mybutton">Button1</button></span>
+     *  <span class="tablink" id="btn2"><button class="mybutton">Button2</button></span>
+     * </div>
+     *
+     * Then calling HighlightActiveTabButton("tabbar", "btn1", "Sample text")
+     *
+     * will replace "placeholder text" with "Sample text" and append " active" to btn1 class:
+     * <span class="tablink" id="btn1"><button class="mybutton active">Button1</button></span>
+     *
+     * The next call HighlightActiveTabButton("tabbar", "btn2", "Sample text2") will result in:
+     * <div id="tabbar">
+     *  <span class="activeTabCaption">Sample text2</span>
+     *  <span class="tablink" id="btn1"><button class="mybutton">Button1</button></span>
+     *  <span class="tablink" id="btn2"><button class="mybutton active">Button2</button></span>
+     * </div>
+     */
+    this.HighlightActiveTabButton = function(tabbarId, activeButtonId, activeTabText) {
+        var tabBar = document.getElementById(tabbarId);
+        if (!tabBar) return;
+        var tabs = tabBar.getElementsByClassName("tablink");
+        for (var e of tabs) {
+            e.firstChild.className = e.firstChild.className.replace(" active", "");
+        }
+        var linkElem = document.getElementById(activeButtonId);
+        if (linkElem) linkElem.firstChild.className += " active";
+        var activeTab = tabBar.getElementsByClassName("activeTabCaption");
+        for (e of activeTab) {
+            e.innerText = activeTabText;
+        }
+    };
 };
 
 /**

--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -1040,7 +1040,7 @@ App.PR = new function() {
      */
     this.PrintItem = function(Item, Player)
     {
-        var res = "<span class='inventoryItem'>" + Item.Description();
+        var res = "<span class='inventoryItem'>" + Item.Description;
         if (SugarCube.settings.inlineItemDetails) {
             res += "</span><br><span class='inventoryItemDetails'>" + Item.Examine(Player, true) + '</span>';
         } else {

--- a/src/000-SCRIPT_OBJ/Player.js
+++ b/src/000-SCRIPT_OBJ/Player.js
@@ -160,6 +160,16 @@ App.Entity.PlayerState = function (){
      * @type {string[]}
      */
     this.BodyEffects = [ ]; // lists effect names
+
+    this.GameStats = {
+        "MoneyEarned":      0,
+        Skills : {}
+    };
+
+    for (var skill in this.Skills) {
+        if (!this.Skills.hasOwnProperty(skill)) continue;
+        this.GameStats.Skills[skill] = {"Failure": 0, "Success": 0};
+    }
 };
 
 /**
@@ -815,6 +825,12 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
 
         if (this._state.debugMode) console.log("SkillRoll(" + SkillName + "," + Difficulty + "):  Target = " + Target + ", DiceRoll = " + DiceRoll + " XPMod="+XpMod+"\n");
 
+        if (DiceRoll >= Target) {
+            this._state.GameStats.Skills[SkillName].Success += 1;
+        } else {
+            this._state.GameStats.Skills[SkillName].Failure += 1;
+        }
+
         if (Scaling == true) return XpMod;
         if (DiceRoll >= Target ) return 1;
         return 0;
@@ -1373,7 +1389,9 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
     }
 
     AdjustMoney (m) {
-        this._state.Money = Math.max(0, (this._state.Money + Math.ceil(m)));
+        var mi = Math.ceil(m);
+        if (mi > 0) {this._state.GameStats.MoneyEarned += mi;}
+        this._state.Money = Math.max(0, (this._state.Money + mi));
     }
 
     RandomAdjustBodyXP (Amount) {
@@ -2172,4 +2190,5 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
         delete this._clothing;
     }
 
+    get GameStats() { return this._state.GameStats; }
 };

--- a/src/002-ASSETS/CSS/custom.css
+++ b/src/002-ASSETS/CSS/custom.css
@@ -213,13 +213,11 @@ input[type="text"] {
 
 /* Style the tabbars */
 .tabbar {
-	overflow: auto;
-	padding: 0px;
-	margin: 0px;
+	overflow: hidden;
 }
 
 .tabbar button {
-	background-color: inherit;
+	background-color: #252525;
 	color: #68d;
 	float: right;
 	border: none;
@@ -227,10 +225,6 @@ input[type="text"] {
 	cursor: pointer;
 	transition: 0.3s;
 	vertical-align: super;
-	padding: 0.25ex;
-	border-right: thin solid gray;
-	padding-left: 4px;
-	padding-right: 4px;
 }
 
 .tabbar button:hover {
@@ -238,7 +232,7 @@ input[type="text"] {
 }
 
 .tabbar button.active {
-	border-bottom: thin solid gray;
+	background-color: #050505;
 }
 
 .tabbar .activeTabCaption {

--- a/src/002-ASSETS/CSS/custom.css
+++ b/src/002-ASSETS/CSS/custom.css
@@ -59,12 +59,19 @@ input[type="text"] {
 	  text-align: left;
 }
 
+button {
+	background-color: #252525;
+	border: none;
+}
+
+button:hover {
+	background-color: #414141;
+}
+
 .storeButton button, .disabledStoreButton button {
-	width: 80px; !important;
-	color: White;
-	background-color: CornflowerBlue;
+	width: 80px;
+	color: CornflowerBlue;
 	font-size: smaller;
-	border-radius: 12px;
 	padding: 4px;
 }
 
@@ -74,11 +81,9 @@ input[type="text"] {
 }
 
 .inventoryButton button, .disabledInventoryButton button {
-	width: 60px; !important;
-	background-color: CornflowerBlue;
-	color: White;
+	width: 60px !important;
+	color: CornflowerBlue;
 	font-size: smaller;
-	border-radius: 12px;
 	padding: 4px;
 }
 
@@ -88,11 +93,9 @@ input[type="text"] {
 }
 
 .wardrobeButton button, .disabledWardrobeButton button {
-	width: 80px; !important;
-	background-color: CornflowerBlue;
-	color: White;
+	width: 70px !important;
+	color: CornflowerBlue;
 	font-size: smaller;
-	border-radius: 12px;
 	padding: 4px;
 }
 
@@ -102,16 +105,15 @@ input[type="text"] {
 }
 
 .cmdButton button, .cmdDisabledButton button {
-	width: 140px; !important;
+	width: 140px !important;
 	color: White;
-	background-color: SlateGrey;
-	font-size: smaller;
+  font-size: smaller;
 	padding: 4px;
 }
 
 .cmdDisabledButton button {
 	opacity: 0.6;
-    cursor: not-allowed !important;
+  cursor: not-allowed !important;
 }
 
 .passage {
@@ -190,7 +192,6 @@ input[type="text"] {
 .inventoryItem .tooltip {
 	visibility: hidden;
 	text-align: left;
-	border-radius: 4px;
 	border: 1px solid rgb(126, 200, 243);
 	padding: 5px 5px;
 	background-color: black;

--- a/src/002-ASSETS/CSS/custom.css
+++ b/src/002-ASSETS/CSS/custom.css
@@ -213,11 +213,13 @@ input[type="text"] {
 
 /* Style the tabbars */
 .tabbar {
-	overflow: hidden;
+	overflow: auto;
+	padding: 0px;
+	margin: 0px;
 }
 
 .tabbar button {
-	background-color: #252525;
+	background-color: inherit;
 	color: #68d;
 	float: right;
 	border: none;
@@ -225,6 +227,10 @@ input[type="text"] {
 	cursor: pointer;
 	transition: 0.3s;
 	vertical-align: super;
+	padding: 0.25ex;
+	border-right: thin solid gray;
+	padding-left: 4px;
+	padding-right: 4px;
 }
 
 .tabbar button:hover {
@@ -232,7 +238,7 @@ input[type="text"] {
 }
 
 .tabbar button.active {
-	background-color: #050505;
+	border-bottom: thin solid gray;
 }
 
 .tabbar .activeTabCaption {

--- a/src/002-ASSETS/CSS/custom.css
+++ b/src/002-ASSETS/CSS/custom.css
@@ -210,3 +210,32 @@ input[type="text"] {
 	padding-left:2em;
 	color: antiquewhite;
 }
+
+/* Style the tabbars */
+.tabbar {
+	overflow: hidden;
+}
+
+.tabbar button {
+	background-color: #252525;
+	color: #68d;
+	float: right;
+	border: none;
+	outline: none;
+	cursor: pointer;
+	transition: 0.3s;
+	vertical-align: super;
+}
+
+.tabbar button:hover {
+	background-color: #414141;
+}
+
+.tabbar button.active {
+	background-color: #050505;
+}
+
+.tabbar .activeTabCaption {
+	color: yellow;
+	vertical-align: sub;
+}

--- a/src/200-WIDGETS/InventoryWidgets.twee
+++ b/src/200-WIDGETS/InventoryWidgets.twee
@@ -98,90 +98,22 @@
 <</nobr>><</widget>>
 
 <<widget "InventoryTable">><<nobr>>
-<table class=".MyTable" style="width:830px;">
-<tbody>
-<tr>
-<<if $args[0] == "food">>
-<<set _Items = setup.player.GetItemByTypes(["food"], true);>>
-	<td colspan=3 style="width:450px;">@@color:yellow;Inventory - Food and Drink@@</td>
-	<td colspan=1 style="width:300px;text-align:right">@@color:grey;Food@@ |
-	<<click "Potions">>
-		<<replace "#InventoryUI">><<InventoryTable "potion">><</replace>>
-	<</click>> | <<click "Loot">>
-		<<replace "#InventoryUI">><<InventoryTable "quest">><</replace>>
-	<</click>> | <<click "Gear">>
-        <<replace "#InventoryUI">><<InventoryTable "gear">><</replace>>
-    <</click>>  | <<click "Misc">>
-         <<replace "#InventoryUI">><<InventoryTable "misc">><</replace>>
-    <</click>>
-    </td>
-<<else>>
-<<if $args[0] == "potion">>
-<<set _Items = setup.player.GetItemByTypes(["potion"], true);>>
-	<td colspan=3 style="width:450px;">@@color:yellow;Inventory - Potions and Drugs@@</td>
-	<td colspan=1 style="width:300px;text-align:right"><<click "Food">>
-		<<replace "#InventoryUI">><<InventoryTable "food">><</replace>>
-	<</click>> | @@color:grey;Potions@@ | <<click "Loot">>
-		<<replace "#InventoryUI">><<InventoryTable "quest">><</replace>>
-	<</click>> | <<click "Gear">>
-        <<replace "#InventoryUI">><<InventoryTable "gear">><</replace>>
-    <</click>>  | <<click "Misc">>
-        <<replace "#InventoryUI">><<InventoryTable "misc">><</replace>>
-    <</click>>
-    </td>
-<<else>>
-<<if $args[0] == "quest">>
-<<set _Items = setup.player.GetItemByTypes(["QUEST", "LOOT_BOX"], true);>>
-	<td colspan=3 style="width:450px;">@@color:yellow;Inventory - Loot Items@@</td>
-	<td colspan=1 style="width:300px;text-align:right"><<click "Food">>
-		<<replace "#InventoryUI">><<InventoryTable "food">><</replace>>
-	<</click>> | <<click "Potions">>
-		<<replace "#InventoryUI">><<InventoryTable "potion">><</replace>>
-	<</click>> | @@color:grey;Loot@@ | <<click "Gear">>
-        <<replace "#InventoryUI">><<InventoryTable "gear">><</replace>>
-    <</click>>  | <<click "Misc">>
-        <<replace "#InventoryUI">><<InventoryTable "misc">><</replace>>
-    <</click>>
-    </td>
-<<else>>
-<<if $args[0] == 'gear'>>
-<<set _Items = setup.player.Wardrobe>>
-	<td colspan=3 style="width:450px;">@@color:yellow;Inventory - Clothing and Weapons@@</td>
-	<td colspan=1 style="width:300px;text-align:right"><<click "Food">>
-		<<replace "#InventoryUI">><<InventoryTable "food">><</replace>>
-	<</click>> | <<click "Potions">>
-		<<replace "#InventoryUI">><<InventoryTable "potion">><</replace>>
-	<</click>>  | <<click "Loot">>
-        <<replace "#InventoryUI">><<InventoryTable "quest">><</replace>>
-    <</click>> | @@color:grey;Gear@@ | <<click "Misc">>
-        <<replace "#InventoryUI">><<InventoryTable "misc">><</replace>>
-    <</click>>
-    </td>
-<<else>>
-<<if $args[0] == 'misc'>>
-<<set _Items = setup.player.GetItemByTypes(["misc", "hair tool", "hair treatment", "basic makeup", "expensive makeup" ], true); >>
-	<td colspan=3 style="width:500px;">@@color:yellow;Inventory - Miscellaneous Items@@</td>
-	<td colspan=1 style="width:250px;text-align:right"><<click "Food">>
-		<<replace "#InventoryUI">><<InventoryTable "food">><</replace>>
-	<</click>> | <<click "Potions">>
-		<<replace "#InventoryUI">><<InventoryTable "potion">><</replace>>
-	<</click>>  | <<click "Loot">>
-        <<replace "#InventoryUI">><<InventoryTable "quest">><</replace>>
-    <</click>> | <<click "Gear">>
-        <<replace "#InventoryUI">><<InventoryTable "gear">><</replace>>
-    <</click>> | @@color:grey;Misc@@
-    </td>
-<</if>>
-<</if>>
-<</if>>
-<</if>>
-<</if>>
-</tr>
-</tbody>
-</table>
-<table class=".MyTable" style="width:830px;">
-<tbody>
+<<run App.PR.HighlightActiveTabButton($args[1], $args[0], "Inventory - " +  $args[2])>>
+<<switch $args[0]>>
+<<case "food">>
+	<<set _Items = setup.player.GetItemByTypes(["food"], true);>>
+<<case "potion">>
+	<<set _Items = setup.player.GetItemByTypes(["potion"], true);>>
+<<case "quest">>
+	<<set _Items = setup.player.GetItemByTypes(["QUEST", "LOOT_BOX"], true);>>
+<<case 'gear'>>
+	<<set _Items = setup.player.Wardrobe>>
+<<case 'misc'>>
+	<<set _Items = setup.player.GetItemByTypes(["misc", "hair tool", "hair treatment", "basic makeup", "expensive makeup" ], true); >>
+<</switch>>
 
+<table class=".MyTable" style="width:830px;">
+<tbody>
 <<if $args[0] == "misc">>
 <tr style="border-bottom:1px solid white;">
 		<td style="width:1em;">&nbsp;</td>

--- a/src/200-WIDGETS/JournalWidgets.twee
+++ b/src/200-WIDGETS/JournalWidgets.twee
@@ -1,0 +1,26 @@
+:: JournalWidgets [widget]
+
+<<widget "JournalList">><<nobr>>
+<<run App.PR.HighlightActiveTabButton($args[1], $args[2], "Journal - " +  $args[3])>>
+<<set _QE = window.App.QuestEngine;>>
+<<if $args[0] == "active">>
+	<<set _entryType to "JOURNAL_ENTRY">>
+<<elseif $args[0] == "completed">>
+	<<set _entryType to "JOURNAL_COMPLETE">>
+<</if>>
+<<if $args[0] == "active" || $args[0] == "completed" >>
+	<<set _QL = _QE.GetQuests($args[0], setup.player);>>
+	<<for _i = 0; _i < _QL.length; _i++>>
+		<<if (_QL[_i]["JOURNAL_ENTRY"] == "HIDDEN")>> <<continue>><</if>>
+		<<set _NPC = setup.player.GetNPC(_QL[_i]["GIVER"]);>>
+		<<print "[" +_NPC.pName() + " - " + _QL[_i]["Title"] + "]<br>";>>
+		<<print window.App.PR.pQuestDialog(_QL[_i]["ID"], _entryType, setup.player, _NPC);>>
+		<<print "<br><br>">>
+		<<if $args[0] == "active" && _QL[_i]["CHECKS"].length != 0>>
+			<<print window.App.PR.pQuestRequirements(_QL[_i]["ID"], setup.player) + "\n";>>
+		<</if>>
+		<<print "<hr>">>
+	<</for>>
+<</if>>
+<</nobr>>
+<</widget>>

--- a/src/200-WIDGETS/JournalWidgets.twee
+++ b/src/200-WIDGETS/JournalWidgets.twee
@@ -24,3 +24,57 @@
 <</if>>
 <</nobr>>
 <</widget>>
+
+<<widget "GameStats">><<nobr>>
+<<run App.PR.HighlightActiveTabButton($args[0], $args[1], "Journal - " +  $args[2])>>
+<<set _GS = setup.player.GameStats>>
+<<if _GS.MoneyEarned > 0>>
+	<<print "You managed to earn " +  _GS.MoneyEarned + " coins.<br><hr>">>
+<</if>>
+<<set _SK = _GS.Skills>>
+<<set _SexSkillsPrinted = false>>
+<<if _SK.AssFucking.Failure + _SK.AssFucking.Success > 0>>
+	<<print "Your ass was used " + (_SK.AssFucking.Failure + _SK.AssFucking.Success) + " times, ">>
+	<<if _SK.AssFucking.Success > 0>>
+		<<print "and " + _SK.AssFucking.Success + " times among them it gave a pleasure!">>
+	<<else>>
+		<<print "but no one enjoied that.">>
+	<</if>>
+	<<print "<br>" >>
+	<<set _SexSkillsPrinted = true>>
+<</if>>
+<<if _SK.BlowJobs.Failure + _SK.BlowJobs.Success > 0>>
+	<<print "You've sucked " + (_SK.BlowJobs.Failure + _SK.BlowJobs.Success) + " dicks, ">>
+	<<if _SK.BlowJobs.Success > 0>>
+		<<print "and satisfied" + _SK.BlowJobs.Success + " of them!">>
+	<<else>>
+		<<print "but each time time you've failed to give a pleasure.">>
+	<</if>>
+	<<print "<br>" >>
+	<<set _SexSkillsPrinted = true>>
+<</if>>
+<<if _SK.HandJobs.Failure + _SK.HandJobs.Success > 0>>
+	<<print _SK.HandJobs.Failure + (_SK.HandJobs.Success + _SK.HandJobs.Failure) + " times you've used your hands to make men happy, ">>
+	<<if _SK.HandJobs.Success > 0>>
+		<<print "and " + _SK.HandJobs.Success + " times it worked quite well!">>
+	<<else>>
+		<<print "yet nobody enjoied that.">>
+	<</if>>
+	<<print "<br>" >>
+	<<set _SexSkillsPrinted = true>>
+<</if>>
+<<if _SK.TitFucking.Failure + _SK.TitFucking.Success > 0>>
+	<<print "Your tits were fucked " + (_SK.TitFucking.Failure + _SK.TitFucking.Success) + " times ">>
+	<<if _SK.TitFucking.Success > 0>>
+		<<print "and " + _SK.TitFucking.Success + " dicks enjoied that!">>
+	<<else>>
+		<<print "and it was nothing but waste of time.">>
+	<</if>>
+	<<print "<br>" >>
+	<<set _SexSkillsPrinted = true>>
+<</if>>
+<<if _SexSkillsPrinted>>
+	<<print "<hr>">>
+<</if>>
+<</nobr>>
+<</widget>>

--- a/src/200-WIDGETS/storeButton.twee
+++ b/src/200-WIDGETS/storeButton.twee
@@ -4,7 +4,7 @@
 <<else>>\
 <<if ($args[0]["QTY"] < 1) or
 (_ST.PlayerCanAfford($args[0]) != 1)>>\
-@@.disabledStoreButton;<<button "BUY">><</button>>@@\
+@@.disabledStoreButton;<<button "BUY">><</button>>@@&nbsp;\
 @@.disabledStoreButton;<<button "BUY ALL">><</button>>@@\
 <<else>>\
 <<if setup.player.MaxItemCapacity($args[0])>>@@.disabledStoreButton;<<button "FULL">><</button>>@@\

--- a/src/200-WIDGETS/storeInventory.twee
+++ b/src/200-WIDGETS/storeInventory.twee
@@ -55,7 +55,7 @@
 <td style="width: 310px;">@@color:lime;Rare Items@@</td>
 <td style="width: 80px;"> </td>
 <td style="width: 60px;"> </td>
-<td style="width: 80px;"> </td>
+<td style="width: 180px;"> </td>
 <td style="width: 80px;"> </td>
 </tr>
 <<if _RI.length == 0>>
@@ -68,7 +68,7 @@
 <td>  <<print _ST.PrintItem(_RI[_i]);>></td>
 <td style="text-align:center;"><<print _RI[_i]["QTY"]>></td>
 <td style="text-align:right;"><<print _ST.GetPrice( _RI[_i]);>></td>
-<td style="text-align:center;"><<storeButton _RI[_i]>></td>
+<td style="text-align:left;"><<storeButton _RI[_i]>></td>
 <td style="text-align:center;"><<storeExamineButton _RI[_i]>></td>
 </tr>
 <</for>>

--- a/src/201-UI/Inventory.twee
+++ b/src/201-UI/Inventory.twee
@@ -3,4 +3,23 @@
 <<set _Drugs = setup.player.GetItemByTypes(["potion"]);>>\
 <<set _Quests = setup.player.GetItemByTypes(["QUEST", "LOOT_BOX"]);>>
 
-<span id="InventoryUI"><<InventoryTable "food">></span>
+<span class="tabbar" id="InventoryTabs">\
+	@@.activeTabCaption;<span>placeholder</span>@@\
+	@@.tablink;#misc;<<button "Misc">>\
+  		<<replace '#InventoryUI'>><<InventoryTable 'misc' 'InventoryTabs' 'Miscellaneous Items'>><</replace>>\
+	<</button>>@@ \
+  	@@.tablink;#gear;<<button "Gear">>\
+  		<<replace '#InventoryUI'>><<InventoryTable 'gear' 'InventoryTabs' 'Clothing and Weapons'>><</replace>>
+	<</button>>@@\
+	@@.tablink;#quest;<<button "Loot">>\
+  		<<replace '#InventoryUI'>><<InventoryTable 'quest' 'InventoryTabs' 'Loot Items'>><</replace>>
+	<</button>>@@\
+	@@.tablink;#potion;<<button "Potions">>\
+  		<<replace '#InventoryUI'>><<InventoryTable 'potion' 'InventoryTabs' 'Potions and Drugs'>><</replace>>
+	<</button>>@@\
+	@@.tablink;#food;<<button "Food">>\
+  		<<replace '#InventoryUI'>><<InventoryTable 'food' 'InventoryTabs' 'Food and Drink'>><</replace>>
+	<</button>>@@\
+</span>
+<span id="InventoryUI"></span>
+<<run $(document).one(':passagedisplay', function(){document.getElementById("food").firstChild.click();});>>

--- a/src/201-UI/Journal.twee
+++ b/src/201-UI/Journal.twee
@@ -1,36 +1,15 @@
 :: Journal [custom-menu]
 @@color:cyan;Interact@@: <<click "Exit" $GameBookmark>><</click>>
 
-@@color:DeepPink;Active Quests@@
-<<set _QE = window.App.QuestEngine;>>\
-<<set _QLA = _QE.GetQuests("active", setup.player);>>\
-<<set _QLC = _QE.GetQuests("completed", setup.player);>>\
-<<if _QLA.length == 0>>\
-No active quests.
-<<else>>\
-<<for _i = 0; _i < _QLA.length; _i++>>\
-<<if (_QLA[_i]["JOURNAL_ENTRY"] != "HIDDEN")>>\
-<<set _NPC = setup.player.GetNPC(_QLA[_i]["GIVER"]);>>\
-//<<print "[" +_NPC.pName() + " - " + _QLA[_i]["Title"] + "]";>>//
-<<print window.App.PR.pQuestDialog(_QLA[_i]["ID"], "JOURNAL_ENTRY", setup.player, _NPC);>>
-<<if _QLA[_i]["CHECKS"].length != 0>>\
-<<print window.App.PR.pQuestRequirements(_QLA[_i]["ID"], setup.player) + "\n";>>
-<</if>>\
-<</if>>\
-<</for>>\
-<</if>>\
+<span class="tabbar" id="JournalTabs">\
+	@@.activeTabCaption;<span>placeholder</span>@@\
+	@@.tablink;#completedQuests;<<button "@@color:yellow;Completed Quests@@">>\
+  		<<replace '#JournalUI'>><<JournalList 'completed' 'JournalTabs' 'completedQuests' 'Completed Quests'>><</replace>>
+	<</button>>@@\
+	@@.tablink;#activeQuests;<<button "@@color:DeepPink;Active Quests@@">>\
+  		<<replace '#JournalUI'>><<JournalList 'active' 'JournalTabs' 'activeQuests' 'Active Quests'>><</replace>>\
+	<</button>>@@ \
+</span>
 <hr>
-@@color:yellow;Completed Quests@@
-<<if _QLC.length == 0>>\
-No completed quests.
-
-<<else>>\
-<<for _i = 0; _i < _QLC.length; _i++>>\
-<<if (_QLC[_i]["JOURNAL_COMPLETE"] != "HIDDEN")>>\
-<<set _NPC = setup.player.GetNPC(_QLC[_i]["GIVER"]);>>\
-//<<print "[" +_NPC.pName() + " - "  + _QLC[_i]["Title"] + "]";>>//
-<<print window.App.PR.pQuestDialog(_QLC[_i]["ID"], "JOURNAL_COMPLETE", setup.player, _NPC);>>
-<</if>>
-
-<</for>>\
-<</if>>
+<span id="JournalUI"></span>
+<<run $(document).one(':passagedisplay', function(){document.getElementById("activeQuests").firstChild.click()});>>

--- a/src/201-UI/Journal.twee
+++ b/src/201-UI/Journal.twee
@@ -1,8 +1,15 @@
 :: Journal [custom-menu]
 @@color:cyan;Interact@@: <<click "Exit" $GameBookmark>><</click>>
+<<set _Reginald = setup.player.GetNPC("Captain");>>
+You open your diary, which you use for tracking events happened since that terrible day when you met \
+<<= window.App.PR.TokenizeString(setup.player, _Reginald, _Reginald.Title())>>, at the tavern. There are a few \
+bookmarks in the notebook to quickly access recent records:
 
 <span class="tabbar" id="JournalTabs">\
 	@@.activeTabCaption;<span>placeholder</span>@@\
+	@@.tablink;#gameStats;<<button "Game Stats">>\
+  		<<replace '#JournalUI'>><<GameStats 'JournalTabs' 'gameStats' 'Game statistic'>><</replace>>
+	<</button>>@@\
 	@@.tablink;#completedQuests;<<button "@@color:yellow;Completed Quests@@">>\
   		<<replace '#JournalUI'>><<JournalList 'completed' 'JournalTabs' 'completedQuests' 'Completed Quests'>><</replace>>
 	<</button>>@@\


### PR DESCRIPTION
Implements tabs as rows of buttons. 

Pros: 
1. Adding a new tab does not require changing code for other tabs any more.
2. Content widget does not need to care about headers (the tabs).

Cons:
1. Tabs styling does not ~perfectly~ fit into the rest of the UI.

Screenshots:

![inventory](https://user-images.githubusercontent.com/43062025/47443240-32226480-d7b4-11e8-9b31-4a237ea812d6.png)
![journal-active-quests](https://user-images.githubusercontent.com/43062025/47443249-35b5eb80-d7b4-11e8-8a76-8f38cd19323e.png)
![journal-completed-quests](https://user-images.githubusercontent.com/43062025/47443254-377faf00-d7b4-11e8-8f05-5f28480125e8.png)

This contributes to #40; 