### PR TITLE
Ass firmness fix

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -680,12 +680,7 @@ App.PR = new function() {
         var fPercent = Player.GetStatPercent("STAT", "Fitness");
 
         if (typeof Arg !== 'undefined') {
-           /**
-            * Removed because "AssFirmness" nouns are relying on a body stat entry that is incomplete. It's breaking the
-            * overnight stat leveling. 
             return this.GetAdjective("BODY", "Ass", aPercent) + ' ' + this.GetAdjective("BODY", "AssFirmness", fPercent);
-            */
-           return this.GetAdjective("BODY", "Ass", aPercent);
         }
 
         var hPercent = Player.GetStatPercent("BODY", "Hips");

--- a/src/000-SCRIPT_OBJ/Player.js
+++ b/src/000-SCRIPT_OBJ/Player.js
@@ -595,8 +595,8 @@ App.Entity.ClothingManager = class ClothingManager {
 
     /**
      * Useful helper method.
-     * @param {string} Slot 
-     * @param {boolean} Lock 
+     * @param {string} Slot
+     * @param {boolean} Lock
      */
     SetLock(Slot, Lock)
     {
@@ -801,7 +801,7 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
         ConfigOb = this.GetStatConfig(Type);
 
         for (Prop in ConfigOb) {
-            if(!ConfigOb.hasOwnProperty(Prop)) continue;
+            if(!ConfigOb.hasOwnProperty(Prop) || !ConfigOb[Prop].hasOwnProperty("START")) continue;
             if (Type == "BODY") this.AdjustBody(Prop, ConfigOb[Prop]["START"]);
             if (Type == "SKILL") this.AdjustSkill(Prop, ConfigOb[Prop]["START"]);
             if (Type == "STAT") this.AdjustStat(Prop, ConfigOb[Prop]["START"]);
@@ -850,9 +850,9 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
 
     /**
      * Moved this here to use it in a couple of different place.
-     * @param {number} Roll 
+     * @param {number} Roll
      * @param {number} Target
-     * @returns {number} 
+     * @returns {number}
      */
     _ModFormula (Roll, Target) {
         return Math.max(0.1, Math.min((Roll/Target), 2.0));
@@ -860,8 +860,8 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
 
     /**
      * Moved this here to use it in a couple of different places.
-     * @param {number} Val 
-     * @param {number} Difficulty 
+     * @param {number} Val
+     * @param {number} Difficulty
      */
     _TargetFormula(Val, Difficulty) {
         return (100 - Math.max(5, Math.min((50 + (Val - Difficulty)), 95)));
@@ -870,18 +870,18 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
     /**
      * Sort of a generic skill roll that just uses the base formulas and doesn't inherently
      * grant xp. Used for arbitrary checks that are derived from meta statistics, etc.
-     * @param {number} SkillVal 
-     * @param {number} Difficulty 
-     * @param {number} Amount 
-     * @param {number} Scaling 
+     * @param {number} SkillVal
+     * @param {number} Difficulty
+     * @param {number} Amount
+     * @param {number} Scaling
      */
     GenericRoll (SkillVal, Difficulty, Amount, Scaling ) {
         Scaling         = Scaling || false;
         var Target      = this._TargetFormula(SkillVal, Difficulty);
         var DiceRoll    = Math.floor(Math.random() * 100);
         var Mod         = this._ModFormula(DiceRoll, Target);
-        if (this._state.debugMode) 
-        console.log("GenericRoll(" + SkillVal + "," + Difficulty + ","+Amount+","+Scaling+ "):  Target=" + 
+        if (this._state.debugMode)
+        console.log("GenericRoll(" + SkillVal + "," + Difficulty + ","+Amount+","+Scaling+ "):  Target=" +
             Target + ", DiceRoll=" + DiceRoll + ", Mod="+Mod+"\n");
 
         if (Scaling == true ) return (Amount * Mod);
@@ -1517,9 +1517,9 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
         Heal = Heal * (( 100 - Math.max(0, Math.min(this.GetStat("STAT", "Toxicity"), 100))) / 100); // Toxicity up to 100 reduces natural healing.
 
         if (OvernightFlag == 0) Heal = Heal / 2;
-        
+
         if (OvernightFlag == 1) {
-            this.AdjustStat("Energy", 
+            this.AdjustStat("Energy",
                 ( Math.floor((this.GetStat("STAT", "Nutrition") / 20) + (this.GetStat("STAT", "Fitness") / 20))));
         }
 
@@ -1761,7 +1761,7 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
                 if (_IsEquipped(Name[i], SlotFlag, this)) return true;
             }
             return false;
-        } 
+        }
 
         return _IsEquipped(Name, SlotFlag, this);
 

--- a/src/001-SCRIPT_DATA/GameData.js
+++ b/src/001-SCRIPT_DATA/GameData.js
@@ -203,10 +203,6 @@ App.Data.Lists = {
                       100 : { "COST" : 575, "STEP" : 1, "ADJECTIVE" : "enormous",    "COLOR" : 16}
                     }
                 },
-                /** 
-                 * This can't be here to be used as just a descriptor as the system will try to level 
-                 * it overnight because it requires 0 XP. It's also lacking a growth/shrink chat and some other
-                 * things to make it a proper stat.
                 "AssFirmness": {  "MIN" : 0, "MAX" : 100,
                     "LEVELING" : {
                         5 :   { "ADJECTIVE" : "flabby", "COLOR" :  1},
@@ -226,7 +222,6 @@ App.Data.Lists = {
                         100 : { "ADJECTIVE" : "smooth and round", "COLOR" : 16}
                     }
                 },
-                */
                 "Waist": { "MIN" : 0, "MAX" : 100, "START" : 46, "CM_MIN" : 40, "CM_MAX": 130,
                     "LEVELING" : {
                         0 : { "COST" : 3000, "STEP" : 1, "ADJECTIVE" : "wasp",           "COLOR" :  1},


### PR DESCRIPTION
Skip stats without "START" properrty when initializing

Player.Init() reads stat config objects and modifies player state in
accordance to the "START" values of the stats. But if a stat is not a
real one (does not level and does not accumulate XP points), it has no
"START" value and may not be put into the PlayerState object. Therefore
we skip stat definition without the "START" attribute. This closes #150.