### PR TITLE
Rewrite namespace definitions to work around a VS Code parser problem

### DIFF
--- a/src/000-SCRIPT_OBJ/000-Bootstrap.js
+++ b/src/000-SCRIPT_OBJ/000-Bootstrap.js
@@ -1,26 +1,26 @@
-var App = {
-	Data: {
-		AvatarMaps: {},
-		Clothes: {},
-		EffectLib: {},
-		Events: {},
-		Drugs: {},
-		Food: {},
-		HSLMAP: {},
-		JobData: {},
-		Loot: {},
-		LootBoxes: {},
-		LootTables: {},
-		Misc: {},
-		NPCS: {},
-		Quests: {},
-		Slots: {},
-		Stores: {},
-		Tarot: {},
-		Whoring: {},
-	},
-	Entity: {}
-};
-
+var App = {};
 // export the App object from the SugarCube closured eval()
 window.App = App;
+
+App.Data = {
+	AvatarMaps: {},
+	Clothes: {},
+	EffectLib: {},
+	Events: {},
+	Drugs: {},
+	Food: {},
+	HSLMAP: {},
+	JobData: {},
+	Loot: {},
+	LootBoxes: {},
+	LootTables: {},
+	Misc: {},
+	NPCS: {},
+	Quests: {},
+	Slots: {},
+	Stores: {},
+	Tarot: {},
+	Whoring: {},
+};
+
+App.Entity = {};


### PR DESCRIPTION
The VS Code parser refuses to see other App entries like App.PR (at least
when there are merge conflicts in files) if App properties are assigned
in declaration and other properties are added afterwards.