### PR TITLE
Complete the workaround for VS Code

### DIFF
--- a/src/000-SCRIPT_OBJ/000-Bootstrap.js
+++ b/src/000-SCRIPT_OBJ/000-Bootstrap.js
@@ -2,24 +2,24 @@ var App = {};
 // export the App object from the SugarCube closured eval()
 window.App = App;
 
-App.Data = {
-	AvatarMaps: {},
-	Clothes: {},
-	EffectLib: {},
-	Events: {},
-	Drugs: {},
-	Food: {},
-	JobData: {},
-	Loot: {},
-	LootBoxes: {},
-	LootTables: {},
-	Misc: {},
-	NPCS: {},
-	Quests: {},
-	Slots: {},
-	Stores: {},
-	Tarot: {},
-	Whoring: {},
-};
+App.Data = {};
+
+App.Data.AvatarMaps = {};
+App.Data.Clothes = {};
+App.Data.EffectLib = {};
+App.Data.Events = {};
+App.Data.Drugs = {};
+App.Data.Food = {};
+App.Data.JobData = {};
+App.Data.Loot = {};
+App.Data.LootBoxes = {};
+App.Data.LootTables = {};
+App.Data.Misc = {};
+App.Data.NPCS = {};
+App.Data.Quests = {};
+App.Data.Slots = {};
+App.Data.Stores = {};
+App.Data.Tarot = {};
+App.Data.Whoring = {};
 
 App.Entity = {};


### PR DESCRIPTION
When object is defined with properties, VS Code parser assumes it is
frozen in terms of properties, and ignores new ones added later.