### PR TITLE
Restore SugarCube buttons but make them smaller

### DIFF
--- a/src/002-ASSETS/CSS/custom.css
+++ b/src/002-ASSETS/CSS/custom.css
@@ -37,7 +37,31 @@
 #menu {
 	position: absolute;
 	bottom: 10px;
-	width: 215px;
+	width: 85%;
+}
+
+#menu li {
+	box-sizing: border-box;
+}
+
+#menu li#menu-item-settings {
+	width: 33%;
+	float: left;
+}
+
+#menu li#menu-item-saves {
+	width: 33%;
+	float: left;
+}
+
+#menu li#menu-item-restart {
+	width: 33%;
+	float: right;
+}
+
+#menu li a {
+	text-transform: none;
+	font-size: small;
 }
 
 #story-caption {
@@ -290,11 +314,6 @@ span.pcText  {
 	left: 45px; */
 }
 
-/* Turn off the default menu */
-#menu-core {
-	display: none;
-}
-
 /* Shrink the ui-bar-body so we can put stuff below it. This div gets refreshed on passage load
    by default and the things we want to place should not be refreshed. */
 #ui-bar-body {
@@ -309,7 +328,7 @@ span.pcText  {
 	line-height: 1em;
 }
 
-#avatarContainer { 
+#avatarContainer {
 	width: 220px;
 	padding: 0 2.5em;
 }

--- a/src/201-UI/Player Score.twee
+++ b/src/201-UI/Player Score.twee
@@ -40,11 +40,6 @@ Coins: <span id="Money"><<print setup.player.Money>></span>
 	<td>Hormones:</td>
 	<td><span id="Hormones"><<print App.PR.pStatMeter("Hormones",setup.player);>></span><<if setup.player.GetStat("STAT","Hormones") < 78>>@@color:cyan;♂@@<<else>><<if setup.player.GetStat("STAT","Hormones") >= 144>>@@color:DeepPink;♀@@<<else>>@@color:orange;⚥<</if>><</if>></td>
 </tr>
-	<td colspan="2">\
-	<<link "Saves">><<run UI.saves()>><</link>> |\
-	<<link "Settings">><<run UI.settings()>><</link>> |\
-	<<link "Restart">><<run UI.restart()>><</link>>\
-	</td>
 </tbody>
 </table>
 <</widget>>


### PR DESCRIPTION
The buttons are put into a single line and typeset with the small font.
Closes #180.

![ui-buttons](https://user-images.githubusercontent.com/43062025/53695242-21fd4000-3db9-11e9-8841-403e6362ba49.png)