### PR TITLE
Interchange inch and foot symbols in the imperial system definition

### DIFF
--- a/src/000-SCRIPT_OBJ/Units.js
+++ b/src/000-SCRIPT_OBJ/Units.js
@@ -44,7 +44,7 @@ App.UnitSystem = function () {
 
 	this.imperialSystemDefinition = {
 		baseLengthFactor  : 1.0/2.54, // conversion from CGS
-		lengthSymbols     : ['&prime;', "&Prime;", "m"],
+		lengthSymbols     : ["&Prime;", '&prime;', "m"],
 		lengthUnits       : ["inch", "foot", "mile"],
 		lengthUnitsPlural : ["inches", "feet", "miles"],
 		lengthScaleFactors: [12, 5280],


### PR DESCRIPTION
The symbols were incorrectly ordered, outputting feet instead of inches
and vise-versa.