### PR TITLE
Track quest accept/complete dates

### DIFF
--- a/src/000-SCRIPT_OBJ/Tasks.js
+++ b/src/000-SCRIPT_OBJ/Tasks.js
@@ -806,6 +806,11 @@ App.Scene = class Scene {
                 if (Opt == "SET" )      this._Player.JobFlags[Name] = Value;
                 if (Opt == "ADD" )      this._Player.JobFlags[Name] += Value;
                 break;
+            case "QUEST":
+                let q = new App.Quest(App.Data.Quests[Name]);
+                if (Value === "START") q.Accept(this._Player);
+                if (Value === "COMPLETE") q.Complete(this._Player);
+                break;
             case "QUEST_FLAG":
                 if (Opt == "DELETE")    delete this._Player.QuestFlags[Name];
                 if (Opt == "SET" )      this._Player.QuestFlags[Name] = Value;
@@ -1669,6 +1674,20 @@ App.Quest = class Quest extends App.Task {
     }
 
     /**
+     * Accepts the quest
+     *
+     * This method is not meant to be used for "Accept" button in the quest dialog because
+     * it creates its own copy of the INTRO scene.
+     * @param {App.Entity.Player} Player
+     */
+    Accept(Player) {
+        let scene = new App.QuestIntroScene(Player, Player.GetNPC(this.Giver()), this._MakeSceneData('INTRO'), this);
+        let checks = {};
+        scene.CalculateScene(checks);
+        scene.CompleteScene();
+    }
+
+    /**
      * Completes the quest
      * @param {App.Entity.Player} Player
      */
@@ -1685,6 +1704,7 @@ App.Quest = class Quest extends App.Task {
      */
     MarkAsCompleted(Player) {
         App.Quest.SetFlag(Player, this.ID(), "COMPLETED");
+        App.Quest.SetFlag(Player, this.ID() + "_CompletedOn", Player.Day);
     }
 
     /**
@@ -1708,6 +1728,26 @@ App.Quest = class Quest extends App.Task {
         return r.filter(function (o) {
             return o["REWARD_TYPE"] == RewardType;
         });
+    }
+
+    /**
+     * Day when the quest was acceped by player
+     * @param {App.Entity.Player} Player
+     * @returns {number}
+     */
+    AcceptedOn(Player) {
+        let r = App.Quest.GetFlag(Player, this.ID() + "_AcceptedOn");
+        return typeof r === 'number' ? r : 1;
+    }
+
+    /**
+     * Day when the quest was completed by player
+     * @param {App.Entity.Player} Player
+     * @returns {number}
+     */
+    CompletedOn(Player) {
+        let r = App.Quest.GetFlag(Player, this.ID() + "_CompletedOn");
+        return typeof r === 'number' ? r : 1;
     }
 };
 
@@ -1752,6 +1792,7 @@ App.QuestIntroScene = class QuestIntroScene extends App.QuestScene {
     CompleteScene() {
         super.CompleteScene();
         App.Quest.SetFlag(this._Player, this._Quest.ID(), "ACTIVE");
+        App.Quest.SetFlag(this._Player, this._Quest.ID() + "_AcceptedOn", this._Player.Day);
     }
 };
 

--- a/src/001-SCRIPT_DATA/QUESTS/bosun_quests.js
+++ b/src/001-SCRIPT_DATA/QUESTS/bosun_quests.js
@@ -70,7 +70,7 @@ App.Data.Quests["ISLA_TAVERN02"] = {
     ],
     "ON_ACCEPT" : [
         {
-            "TYPE" : "QUEST_FLAG", "NAME" : "SMUGGLER_PICKUP", "VALUE" : "ACTIVE"
+            "TYPE" : "QUEST", "NAME" : "SMUGGLER_PICKUP", "VALUE" : "START"
         }
     ],
     "REWARD": [

--- a/src/001-SCRIPT_DATA/QUESTS/paola_quests.js
+++ b/src/001-SCRIPT_DATA/QUESTS/paola_quests.js
@@ -7,7 +7,7 @@ App.Data.Quests["PAOLA_FETCH"] = {
         {"TYPE": "QUEST_ITEM", "NAME": "bag of mojo", "VALUE": 1 }
     ],
     "ON_ACCEPT" : [
-        { "TYPE" : "QUEST_FLAG", "NAME" : "VOODOO_PICKUP", "VALUE" : "ACTIVE" }
+        { "TYPE" : "QUEST", "NAME" : "VOODOO_PICKUP", "VALUE" : "START" }
     ],
     "REWARD": [
         {"REWARD_TYPE": "MONEY", "AMOUNT": 200 }

--- a/src/001-SCRIPT_DATA/QUESTS/petey_quests.js
+++ b/src/001-SCRIPT_DATA/QUESTS/petey_quests.js
@@ -41,7 +41,7 @@ App.Data.Quests["LORD_ROWE_PORNO_DELIVERY"] = {
         {"TYPE": "FLAG", "NAME": "LORD_ROWE_DELIVERY", "VALUE": "COMPLETED" }
     ],
     "ON_ACCEPT" : [
-        { "TYPE" : "QUEST_FLAG", "NAME" : "LORD_ROWE_DELIVERY", "VALUE" : "ACTIVE" },
+        { "TYPE" : "QUEST", "NAME" : "LORD_ROWE_DELIVERY", "VALUE" : "START" },
         { "TYPE" : "QUEST_ITEM", "NAME" : "lolita book", "VALUE" : 1 }
     ],
     "REWARD": [

--- a/src/001-SCRIPT_DATA/QUESTS/reginald_quests.js
+++ b/src/001-SCRIPT_DATA/QUESTS/reginald_quests.js
@@ -4,7 +4,7 @@ App.Data.Quests["Q001"] = {
     "PRE": [ ],
     "POST": [
         {
-            "TYPE" : "QUEST_FLAG", "NAME": "Q001b", "VALUE": "ACTIVE"
+            "TYPE" : "QUEST", "NAME": "Q001b", "VALUE": "START"
         }
     ],
     "CHECKS": [],

--- a/src/200-WIDGETS/JournalWidgets.twee
+++ b/src/200-WIDGETS/JournalWidgets.twee
@@ -9,13 +9,30 @@
 <</if>>
 <<if $args[0] == "active" || $args[0] == "completed" >>
 	<<set _QL = App.Quest.List($args[0], setup.player);>>
+	<<if $args[0] == "completed">>
+		<<run _QL.sort((l, r) => r.CompletedOn(setup.player) - l.CompletedOn(setup.player))>>
+	<<else>>
+		<<run _QL.sort((l, r) => l.AcceptedOn(setup.player) - r.AcceptedOn(setup.player))>>
+	<</if>>
 	<<if _QL.length == 0>>
 		// No $args[0] quests.//
 	<<else>>
 		<<for _q range _QL>>
 			<<if (_q.JournalEntry === "HIDDEN")>> <<continue>> <</if>>
 			<<set _NPC = setup.player.GetNPC(_q.Giver());>>
-			//<<print "[" +_NPC.pName() + " - " + _q.Title() + "]\n";>>//
+			<<set _acceptDay = _q.AcceptedOn(setup.player)>>
+			<<set _completeDay = _q.CompletedOn(setup.player)>>
+			<<if $args[0] == "active">>
+				<div style="float:left">Day <<= _acceptDay>>
+				<<if setup.player.Day !== _acceptDay>> (<<=setup.player.Day - _acceptDay>> days ago)<</if>>
+				</div>
+			<<else>>
+				<div style="float:left">Day <<= _completeDay>>
+				(<<if _completeDay === _acceptDay>>same day <<else>>in <<= _completeDay - _acceptDay>> days<</if>> after accepting)
+				</div>
+			<</if>>
+			<div style="float:right">[ <<=_NPC.pName()>>  -  <<=_q.Title()>> ]</div>
+			<br>
 			<<print window.App.PR.pQuestDialog(_q.ID(), _entryType, setup.player, _NPC);>>
 			<<if $args[0] == "active" && _q.Checks.length !== 0>>
 				<br><<print window.App.PR.pQuestRequirements(_q.ID(), setup.player) + "\n";>>


### PR DESCRIPTION
When accepting or completing a quest, set an additional quest flag to
memorize the day when it happened. The dates are shown in the journal
then, to make it look more like a personal diary.

Add new action type "QUEST" for triggers, that accept quest name
("NAME") and value ("VALUE"). The values currently are "START" to
accept a quest and "COMPLETE" to complete the quest. In additiona to
setting the quest state, this action sets the accept/complete date for
the quest.

Journal screenshots:
![active](https://user-images.githubusercontent.com/43062025/53984513-c2d15f80-4119-11e9-9333-56e803ce8cb2.png)
![completed](https://user-images.githubusercontent.com/43062025/53984516-c5cc5000-4119-11e9-8ba4-413a88f28344.png)

WIP: I don't know yet what to do with the currently active quests when applying this update:
![unknown-dates](https://user-images.githubusercontent.com/43062025/53984580-e5637880-4119-11e9-8f96-0a8f80fa50c1.png)
