### PR TITLE
Fix crash when PICK_ITEM reward results in money bonus

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -669,6 +669,7 @@ App.PR = new function() {
             var reward = scene.RewardItems();
             if (reward.Pay > 0) { Pay += scene.RewardItems().Pay; }
             for (const ri of reward.Items) {
+                if (typeof ri === 'number') continue; // we had to put number here too in order to maintain order
                 var n = App.Item.SplitId(ri["Name"]);
                 var oItem = App.Item.Factory(n.Category, n.Tag);
                 Items.push(oItem.Description + " x " + ri["Value"]);

--- a/src/000-SCRIPT_OBJ/Tasks.js
+++ b/src/000-SCRIPT_OBJ/Tasks.js
@@ -765,9 +765,7 @@ App.Scene = class Scene {
             case "CLOTHES":
             case "PICK_ITEM":
                 var itemRec = this._RewardItems.Items.shift();
-                if (typeof(itemRec) === 'number') {
-                    this._Player.AdjustMoney(itemRec);
-                } else {
+                if (typeof (itemRec) !== 'number') { // if item was converted to money, its value was added to the _RewardItems.Pay
                     var n = App.Item.SplitId(itemRec["Name"]);
                     if (itemRec.Value > 0) {
                         this._Player.AddItem(n.Category, n.Tag, Value, Opt);


### PR DESCRIPTION
The rewards array has to contain all the items in the same order as they
were generated by CalculateScene() in order to be properly processed in
CompleteScene() when invoking _ApplyReward(). Therefore if PICK_ITEM
results in money reward (player own the item already), we have to put
number in the rewards array. Notice, that the amount is added to the
scene pay immidiately at the same time. Then we have to skip numbers
when looping over the rewards array.