### PR TITLE
Fix default condition and types for quest checks

### DIFF
--- a/src/000-SCRIPT_OBJ/Tasks.js
+++ b/src/000-SCRIPT_OBJ/Tasks.js
@@ -1579,12 +1579,21 @@ App.Quest = class Quest extends App.Task {
         var Condition   = Req["CONDITION"];
         var Option      = Req["OPT"];
 
-        if (Condition === undefined) Condition = "gte";
+        if (Condition === undefined) {
+            if (typeof Value === 'string') {
+                Condition = "eq";
+            } else {
+                Condition = "gte";
+            }
+        }
         if (typeof Name !== 'undefined' && Name.charAt(0) == '-') {
             Name = Name.slice(1);
             Condition = "lte";
         }
         switch (Type) {
+            case "FLAG":
+                Type = "QUEST_FLAG";
+                break;
             case "NPC_MOOD":
                 Type = "NPC_STAT";
                 Option = Name;


### PR DESCRIPTION
The default condition for string values in quest checks is "eq" (not
"gte") and if check type is "FLAG" it means "QUEST_FLAG".