### PR TITLE
Use item IDs in task requirements

### DIFF
--- a/src/000-SCRIPT_OBJ/Tasks.js
+++ b/src/000-SCRIPT_OBJ/Tasks.js
@@ -178,10 +178,10 @@ App.Task = class Task {
                     }
                     break;
                 case "ITEM":
-                    if (Player.GetItemByName(Name) === undefined) {
+                    if (Player.GetItemById(Name) === undefined) {
                         StatusFlag = false;
                         ReqString = "@@color:red;Missing item '" + Name + "' x" + Value + "@@";
-                    } else if (Task._Cmp( Player.GetItemByName(Name).Charges(), Value, Condition) == false) {
+                    } else if (Task._Cmp(Player.GetItemById(Name).Charges(), Value, Condition) == false) {
                         StatusFlag = false;
                         ReqString = "@@color:red;Missing item '" + Name + "' x" + Value + "@@";
                     }
@@ -1189,7 +1189,7 @@ App.Job = class Job extends App.Task {
                     Player.AdjustMoney(Math.floor(Value * -1.0));
                     break;
                 case "ITEM":
-                    var o = Player.GetItemByName(Name);
+                    var o = Player.GetItemById(Name);
                     o.RemoveCharges(Value);
                     break;
                 case "TIME":

--- a/src/001-SCRIPT_DATA/JOBS/jarvis_jobs.js
+++ b/src/001-SCRIPT_DATA/JOBS/jarvis_jobs.js
@@ -6,11 +6,11 @@ App.Data.JobData["JARV01"] =  {
     "HIDDEN" : true,
     "COST" : [  { "TYPE" : "TIME", "VALUE" : 1 },
         { "TYPE" : "STAT", "NAME" : "Energy", "VALUE" : 3 },
-        { "TYPE" : "ITEM", "NAME" : "fortified wine", "VALUE" : 1 }
+        { "TYPE" : "ITEM", "NAME" : "FOOD/fortified wine", "VALUE" : 1 }
     ],
     "REQUIREMENTS" : [
         { "TYPE" : "QUEST",     "NAME" : "THEBACKDOOR",         "VALUE" : "ACTIVE",     "CONDITION" : "eq"  },
-        { "TYPE" : "ITEM",      "NAME" : "fortified wine",      "VALUE" : 1,            "CONDITION" : "gte" }
+        { "TYPE" : "ITEM",      "NAME" : "FOOD/fortified wine",      "VALUE" : 1,            "CONDITION" : "gte" }
     ],
     "INTRO" :   "NPC_NAME wouldn't normally stoop so low as to fuck a common whore behind a tavern, but perhaps if you gave him a little 'mental lubrication' first he might become a little more compliant?",
     "START" : "You slowly saunter up to NPC_NAME's table making sure to stick out your bust and give your arse an extra wiggle. You've clearly got his attention but he briskly turns his head to side. Undeterred "+


### PR DESCRIPTION
Since the `App.Quest` class generates IDs  (QUEST/xxx) for item requirements, and their is only a single job which uses items, let's switch it over to ID as well for consistency inside the engine.