### PR TITLE
Print target numerical values in quest meters

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -1,5 +1,7 @@
 App.PR = new function() {
 
+    this.numericalMeters = false;
+
 	/** Shortcut
 	 */
 	this.lengthString = function(x, compact) {
@@ -639,7 +641,7 @@ App.PR = new function() {
         p = Math.floor( ((c/m)*100));
         console.log("pMeter("+c+","+m+",0) called by pQuestMeter");
 
-        return "<span id=\"fixed-font\">" + this.pMeter(c, m, 0) +"</span>&nbsp;"+ p +"% "+Name;
+        return `<span id=\"fixed-font\">${this.pMeter(c, m, 0)}${this.numericalMeters ? '/' + GoalValue : ''}</span>&nbsp; ${p} % ${Name}`;
     };
 
     /**


### PR DESCRIPTION
When it's enabled in settings.
![numeric-quest-meters](https://user-images.githubusercontent.com/43062025/54085093-f4c10c80-4339-11e9-94f1-226bd93ce4ed.png)
