### PR TITLE
Allow users to enable autosaving at cabin in the debug mode

### DIFF
--- a/src/100-SHIP/Cabin.twee
+++ b/src/100-SHIP/Cabin.twee
@@ -1,4 +1,4 @@
-:: Cabin [no-teleport event]
+:: Cabin [no-teleport event hideout]
 Your "cabin" is really a converted jail cell used for holding prisoners -- or in your case, a slave. It's been poorly \
 fitted with some decrepit furnishings and just enough amenities for you to sustain your life as a whore. \
 <<if setup.player.QuestFlags.CABIN_DECORATION eq "COMPLETED">>Although you have managed to secure some small comforts to brighten up the place a little. <</if>>\

--- a/src/110-DEBUG/DebugPassage.twee
+++ b/src/110-DEBUG/DebugPassage.twee
@@ -8,7 +8,20 @@
 <<click "Combat Test" "CombatTest">>\
 <<run setup.Combat.InitializeScene();>>\
 <<run setup.Combat.LoadEncounter("TEST_FIGHT_1");>>\
-<</click>>\ 
+<</click>>\
+
+<<if Array.isArray(Config.saves.autosave) && Config.saves.autosave.includes("hideout")>>
+	<<link "Disable autosaving at safe locations" "DebugPassage">>
+		<<set Config.saves.autosave = Config.saves.autosave.filter(s => s !== "hideout")>>
+	<</link>>
+<<else>>
+	<<link "Enable autosaving at safe locations" "DebugPassage">>
+		<<if !Array.isArray(Config.saves.autosave)>>
+			<<set Config.saves.autosave = []>>
+		<</if>>
+		<<run Config.saves.autosave.push("hideout");>>
+	<</link>>
+<</if>>
 
 @@color:silver;Items Menu@@
 [[Acquire everything|DebugPassage][setup.player.AcquireAllItems();]]


### PR DESCRIPTION
Add links to the debug passage to enable or disable autosaving at
passages with "hideout" tag. Currently the only such passage is the
Cabin.

Closes #198.