### PR TITLE
Fix crash in App.PR.pQuestRequirements()

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -504,7 +504,7 @@ App.PR = new function() {
             bMeter = false;
             pString = "";
 
-            if (Name.charAt(0) == '-') {
+            if (Name !== undefined && Name.charAt(0) == '-') {
                 Name = Name.slice(1);
                 Invert = 1;
             }


### PR DESCRIPTION
If check type is MONEY, NAME may be undefined.