### PR TITLE
Add futa stat and activating item

### DIFF
--- a/src/000-SCRIPT_OBJ/Helpers.js
+++ b/src/000-SCRIPT_OBJ/Helpers.js
@@ -922,6 +922,33 @@ App.PR = new function() {
 		};
 
     /**
+     * Print how does the futa state matches current body state
+     * @param {App.Entity.Player} Player
+     * @returns {string}
+     */
+    this.pFutaStatus = function (Player) {
+        const pFuta = Player.GetStatPercent("STAT", "Futa");
+        const hormones = Player.GetStat("STAT", "Hormones");
+        if ((hormones > 100)) {
+            const pPenis = Player.GetStatPercent("BODY", "Penis");
+            const dp = pFuta - pPenis;
+            if (dp > 90) return "You crave for a bigger penis."
+            if (dp > 60) return "You feel an urge to grow a bigger penis."
+            if (dp > 30) return "You are pretty sure a bigger penis would be a good thing to get."
+            if (dp > 5) return "You feel your penis could be a bit bigger."
+            return "You consider your penis size to be about right for you."
+        } else if (hormones) {
+            const pBust = Player.GetStatPercent("BODY", "Bust");
+            const db = pFuta - pBust;
+            if (db > 90) return "You crave for bigger tits."
+            if (db > 60) return "You feel an urge to grow your boobs."
+            if (db > 30) return "You are pretty sure bigger tits would be a good thing to get."
+            if (db > 5) return "You feel your bust could be a bit bigger."
+            return "You consider your bust size to be about right for you."
+        }
+    }
+
+    /**
      * Prints out a description of the Player's height statistic.
      * @param {App.Entity.Player} Player
      * @returns {string}

--- a/src/000-SCRIPT_OBJ/Player.js
+++ b/src/000-SCRIPT_OBJ/Player.js
@@ -55,7 +55,8 @@ App.Entity.PlayerState = function (){
         "Fitness":          0,
         "Toxicity":         0,
         "Hormones":         0,
-        "Energy":           0
+        "Energy":           0,
+        "Futa":             0
     };
 
     this.CoreStatsXP = {
@@ -67,7 +68,8 @@ App.Entity.PlayerState = function (){
         "Fitness":          0,
         "Toxicity":         0,
         "Hormones":         0,
-        "Energy":           0
+        "Energy":           0,
+        "Futa":             0,
     };
 
     this.BodyStats = {
@@ -2307,6 +2309,16 @@ App.Entity.Player = /** @class Player @type {Player} */ class Player {
      */
     GetReels() {
         return this.Inventory.EquippedReelItems();
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    IsFuta() {
+        if (this._state.CoreStats["Futa"] > 0) {
+            return true;
+        }
+        return false;
     }
 
     // endregion

--- a/src/001-SCRIPT_DATA/CLOTHES/uncatagorized_clothes.js
+++ b/src/001-SCRIPT_DATA/CLOTHES/uncatagorized_clothes.js
@@ -37,6 +37,16 @@ App.Data.Clothes["choker"] = {
     "WearEffect": [ "FEMININE_CLOTHING" ]
 };
 
+App.Data.Clothes["ancient metal collar"] = {
+    "Name": "ancient metal collar",
+    "ShortDesc": "an ancient metal collar",
+    "LongDesc": "An ancient collar made of metal inlaid with a few big gems of various colours.",
+    "Slot": "Neck", "Restrict": ["Neck"], "Color": "silver",
+    "Style": "LEGENDARY", "Type" : "ACCESSORY",
+    "WearEffect": [ "FUTA_COLLAR" ],
+    "InMarket" : false
+};
+
 // NIPPLES SLOT
 
 // BRA SLOT

--- a/src/001-SCRIPT_DATA/EFFECTS/effects_unique.js
+++ b/src/001-SCRIPT_DATA/EFFECTS/effects_unique.js
@@ -273,3 +273,13 @@ App.Data.EffectLib["BROW_THINNER"] = {
    "VALUE" : 250,
        "KNOWLEDGE" : [ "Eyebrows Thinner++", ]
 };
+
+App.Data.EffectLib["FUTA_COLLAR"] = {
+    "FUN" : /** @param {App.Entity.Player} p
+     @param {App.Items.Consumable} o*/
+    function(o,p) {
+        p.AdjustStatXP('Futa', 50);
+    },
+    "VALUE" : 50,
+    "KNOWLEDGE" : [ "Futanari Identity+" ]
+};

--- a/src/001-SCRIPT_DATA/GameData.js
+++ b/src/001-SCRIPT_DATA/GameData.js
@@ -787,6 +787,25 @@ App.Data.Lists = {
                       200 : { "COST" : 190, "STEP" : 1, "ADJECTIVE" : "ladylike"    , "COLOR" : 16}
                     }
                 },
+                "Futa": { "MIN" : 0, "MAX" : 100, "START" : 0,
+                "LEVELING" : {
+                     5 : { "COST" :  100, "STEP" : 1, "ADJECTIVE" : "shy"           , "COLOR" :  1},
+                    10 : { "COST" :  100, "STEP" : 1, "ADJECTIVE" : "timid"         , "COLOR" :  2},
+                    15 : { "COST" :  125, "STEP" : 1, "ADJECTIVE" : "timid"         , "COLOR" :  3},
+                    20 : { "COST" :  125, "STEP" : 1, "ADJECTIVE" : "diffident"     , "COLOR" :  4},
+                    30 : { "COST" :  200, "STEP" : 1, "ADJECTIVE" : "diffident"     , "COLOR" :  5},
+                    32 : { "COST" :  225, "STEP" : 1, "ADJECTIVE" : "open"          , "COLOR" :  6},
+                    38 : { "COST" :  250, "STEP" : 1, "ADJECTIVE" : "open"          , "COLOR" :  7},
+                    46 : { "COST" :  300, "STEP" : 1, "ADJECTIVE" : "outright"      , "COLOR" :  8},
+                    54 : { "COST" :  350, "STEP" : 1, "ADJECTIVE" : "outright"      , "COLOR" :  9},
+                    62 : { "COST" :  400, "STEP" : 1, "ADJECTIVE" : "daring"        , "COLOR" : 10},
+                    71 : { "COST" :  450, "STEP" : 1, "ADJECTIVE" : "daring"        , "COLOR" : 12},
+                    80 : { "COST" :  500, "STEP" : 1, "ADJECTIVE" : "daring"        , "COLOR" : 13},
+                    89 : { "COST" :  550, "STEP" : 1, "ADJECTIVE" : "perfect"       , "COLOR" : 15},
+                    98 : { "COST" :  600, "STEP" : 1, "ADJECTIVE" : "perfect"       , "COLOR" : 16},
+                   100 : { "COST" : 1500, "STEP" : 1, "ADJECTIVE" : "perfect"       , "COLOR" : 16}
+                }
+            },
                 "Energy": { "MIN" : 0, "MAX" : 10, "START" : 3,
 					"LEVELING" : {
 						"NONE" : { "COST" : 0, "STEP" : 0 }

--- a/src/103-ABAMOND/TreasureRoom.twee
+++ b/src/103-ABAMOND/TreasureRoom.twee
@@ -3,4 +3,13 @@ After a long and arduous trek you've finally made your way into the deepest and 
 
 Towards the back of the room you see a small opening. Upon inspecting it, it appears to be a secret tunnel leading back to the surface.
 
+<<set _QE = window.App.QuestEngine>>\
+<<set $GameBookmark = passage(); >>\
+<<if _QE.QuestCompleted(setup.player, "FUTACOLLAR") == false>>
+In one of the corners you notice remains of a human skeleton. Upon a closer look you notice something shining near it. Trying to take that thing out you discover that it was bound around the neck of the human, whose dead remains seem to be lying in this chamber for hundreds of years. Fortunately, it is not hard to pull it out through already rotten bones. Slightly cleaning the object you recognize a neck collar, made of a heavy, shining metal, and decorated with a few big gems. You decide to take the collar with you.
+
+<<run setup.player.AddItem("CLOTHES", "ancient metal collar", 1);>>\
+<<run _QE.SetQuestFlag(setup.player, "FUTACOLLAR", "COMPLETED");>>
+<</if>>
+
 @@color:lime;Travel@@: [[Into the Jungle|Jungle]]

--- a/src/200-WIDGETS/printPlayerDescription.twee
+++ b/src/200-WIDGETS/printPlayerDescription.twee
@@ -11,6 +11,7 @@ You have a <<print App.PR.pFace(setup.player);>> <<print App.PR.pHair(setup.play
 <<print App.PR.pHips(setup.player);>> <<print App.PR.pWaist(setup.player);>> and \
 <<print App.PR.pFigure(setup.player);>>. You have <<print App.PR.pPenis(setup.player);>> and \
 <<print App.PR.pBalls(setup.player);>> between your legs.
+<<if setup.player.IsFuta()>><<print window.App.PR.pFutaStatus(setup.player);>><</if>>
 
 You consider your natural beauty to be <<print App.PR.pBeauty(setup.player);>>.
 The fetish appeal of your body is <<print App.PR.pFetish(setup.player);>>.\
@@ -23,6 +24,7 @@ You have a <<print window.App.PR.pFace(setup.player);>> <<print window.App.PR.pH
 <<print window.App.PR.pHips(setup.player);>> <<print window.App.PR.pWaist(setup.player);>> and \
 <<print window.App.PR.pFigure(setup.player);>>. You have <<print window.App.PR.pPenis(setup.player);>> and \
 <<print window.App.PR.pBalls(setup.player);>> between your legs.
+<<if setup.player.IsFuta()>><<print window.App.PR.pFutaStatus(setup.player);>><</if>>
 
 You consider your natural beauty to be <<print window.App.PR.pBeauty(setup.player);>>.
 The fetish appeal of your body is <<print window.App.PR.pFetish(setup.player);>>.\


### PR DESCRIPTION
Adds a short scene to the treasure room in Abamond, where player can find an ancient collar. The collar (when is worn) increases  a new stat ("Futa"). The "Futa" stat blocks penis, bust, and balls shrinking if their stats are lower or equal to the futa stat. Also, if the balls stat percent is lower than the futa one, balls do not produce hormonal shift. If, however, the futa stat is higher than the penis or bust stat, it results in willpower drain down to 15.

This was work in progress, but I submit it as is, since it is unlikely I will contribute to the game in the future.